### PR TITLE
fix: recover stream immediately when ffmpeg exits mid-stream

### DIFF
--- a/src/camera/camera-manager.test.ts
+++ b/src/camera/camera-manager.test.ts
@@ -17,6 +17,7 @@ vi.mock('./camera-stream.js', () => ({
     cameraId: _id,
     cameraName: name,
     state: 'idle',
+    onUnexpectedExit: null,
     start: vi.fn().mockResolvedValue(undefined),
     stop: vi.fn().mockResolvedValue(undefined),
   })),
@@ -172,6 +173,37 @@ describe('CameraManager backoff', () => {
     expect(tokenManager.fetchVideoToken).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1);
     expect(tokenManager.fetchVideoToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers immediately when ffmpeg exits mid-stream', async () => {
+    await startWithCamera();
+    const stream = getStream();
+
+    // Successful start — stream is active
+    tokenManager.emit('videoToken', 'cam-1', makeConfig());
+    await vi.advanceTimersByTimeAsync(0);
+    tokenManager.fetchVideoToken.mockClear();
+
+    // Simulate ffmpeg dying mid-stream
+    stream.onUnexpectedExit();
+
+    expect(tokenManager.fetchVideoToken).toHaveBeenCalledWith('cam-1');
+  });
+
+  it('does not recover on mid-stream exit after manager is stopped', async () => {
+    await startWithCamera();
+    const stream = getStream();
+
+    tokenManager.emit('videoToken', 'cam-1', makeConfig());
+    await vi.advanceTimersByTimeAsync(0);
+
+    await manager.stop();
+    tokenManager.fetchVideoToken.mockClear();
+
+    // Simulate ffmpeg dying after stop
+    stream.onUnexpectedExit?.();
+
+    expect(tokenManager.fetchVideoToken).not.toHaveBeenCalled();
   });
 
   it('does not retry when manager is stopped', async () => {

--- a/src/camera/camera-manager.ts
+++ b/src/camera/camera-manager.ts
@@ -35,6 +35,7 @@ export class CameraManager {
 
     for (const cam of cameras) {
       const stream = new CameraStream(cam.id, cam.name, this.rtspBaseUrl);
+      stream.onUnexpectedExit = () => this.handleUnexpectedExit(cam.id);
       this.streams.set(cam.id, stream);
     }
 
@@ -114,5 +115,16 @@ export class CameraManager {
     }
 
     this.activeStarts.delete(cameraId);
+  }
+
+  private handleUnexpectedExit(cameraId: string): void {
+    if (!this.running) return;
+
+    const stream = this.streams.get(cameraId);
+    const name = stream?.cameraName ?? cameraId;
+    log.warn({ camera: name }, 'Stream died mid-stream, fetching fresh token to recover');
+
+    this.activeStarts.delete(cameraId);
+    this.tokenManager.fetchVideoToken(cameraId);
   }
 }

--- a/src/camera/camera-stream.test.ts
+++ b/src/camera/camera-stream.test.ts
@@ -188,6 +188,68 @@ describe('CameraStream.start', () => {
   });
 });
 
+describe('CameraStream ffmpeg mid-stream exit recovery', () => {
+  let stream: CameraStream;
+  let exitHandler: (code: number | null) => void;
+
+  beforeEach(async () => {
+    stream = new CameraStream('cam-123', 'test-camera', 'rtsp://localhost:8554');
+
+    (stream as any).videoPort = 12345;
+    (stream as any)._state = 'streaming';
+
+    const { spawn } = await import('node:child_process');
+    vi.mocked(spawn).mockReturnValue({
+      stdin: { write: vi.fn(), end: vi.fn() },
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn((event: string, handler: any) => {
+        if (event === 'exit') exitHandler = handler;
+      }),
+      kill: vi.fn(),
+    } as any);
+
+    (stream as any).startFfmpeg();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets state to error when ffmpeg exits while streaming', () => {
+    exitHandler(1);
+
+    expect(stream.state).toBe('error');
+  });
+
+  it('invokes onUnexpectedExit callback when ffmpeg exits while streaming', () => {
+    const callback = vi.fn();
+    stream.onUnexpectedExit = callback;
+
+    exitHandler(0);
+
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it('does not invoke callback when ffmpeg exits during idle/connecting state', () => {
+    const callback = vi.fn();
+    stream.onUnexpectedExit = callback;
+    (stream as any)._state = 'idle';
+
+    exitHandler(0);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('does not set state to error when stream is already idle', () => {
+    (stream as any)._state = 'idle';
+
+    exitHandler(0);
+
+    expect(stream.state).toBe('idle');
+  });
+});
+
 describe('CameraStream ffmpeg SDP', () => {
   let stream: CameraStream;
   let stdinWrite: ReturnType<typeof vi.fn>;

--- a/src/camera/camera-stream.ts
+++ b/src/camera/camera-stream.ts
@@ -30,6 +30,9 @@ export class CameraStream {
   private h264Fmtp: string | null = null;
   private _state: StreamState = 'idle';
 
+  /** Called when ffmpeg exits unexpectedly while the stream was active. */
+  onUnexpectedExit: (() => void) | null = null;
+
   constructor(
     readonly cameraId: string,
     readonly cameraName: string,
@@ -429,6 +432,12 @@ export class CameraStream {
     this.ffmpeg.on('exit', (code) => {
       log.warn({ camera: this.cameraName, code }, 'ffmpeg exited');
       this.ffmpeg = null;
+
+      if (this._state === 'streaming') {
+        this._state = 'error';
+        log.error({ camera: this.cameraName, code }, 'ffmpeg exited unexpectedly while streaming');
+        this.onUnexpectedExit?.();
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

- When ffmpeg exits while a stream is active (e.g., WebRTC connection drops), the stream previously sat dead until the next 10-minute token refresh
- Now `CameraStream` detects the unexpected exit, sets state to `error`, and notifies `CameraManager` which immediately fetches a fresh token to restart the pipeline
- Adds `onUnexpectedExit` callback on `CameraStream`, wired up by `CameraManager`

## Test plan

1. 6 new tests across `camera-stream.test.ts` and `camera-manager.test.ts`
2. Verify ffmpeg exit while streaming sets state to `error`
3. Verify callback fires only when state was `streaming` (not `idle`/`connecting`)
4. Verify CameraManager triggers immediate token re-fetch on callback
5. Verify no recovery attempt after manager is stopped

🤖 Generated with [Claude Code](https://claude.com/claude-code)