### PR TITLE
feat: seamless stream handoff during token refresh

### DIFF
--- a/src/camera/camera-manager.test.ts
+++ b/src/camera/camera-manager.test.ts
@@ -11,7 +11,7 @@ vi.mock('../utils/logger.js', () => ({
   }),
 }));
 
-// Stub CameraStream so we can control start()/stop() behavior
+// Stub CameraStream so we can control start()/stop()/reconnect() behavior
 vi.mock('./camera-stream.js', () => ({
   CameraStream: vi.fn().mockImplementation((_id: string, name: string) => ({
     cameraId: _id,
@@ -20,6 +20,7 @@ vi.mock('./camera-stream.js', () => ({
     onUnexpectedExit: null,
     start: vi.fn().mockResolvedValue(undefined),
     stop: vi.fn().mockResolvedValue(undefined),
+    reconnect: vi.fn().mockResolvedValue(undefined),
   })),
 }));
 
@@ -204,6 +205,63 @@ describe('CameraManager backoff', () => {
     stream.onUnexpectedExit?.();
 
     expect(tokenManager.fetchVideoToken).not.toHaveBeenCalled();
+  });
+
+  it('uses reconnect instead of start when stream is already streaming', async () => {
+    await startWithCamera();
+    const stream = getStream();
+
+    // First token → normal start
+    tokenManager.emit('videoToken', 'cam-1', makeConfig());
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Stream is now active
+    stream.state = 'streaming';
+    stream.start.mockClear();
+
+    // Second token → should use reconnect
+    tokenManager.emit('videoToken', 'cam-1', makeConfig());
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(stream.reconnect).toHaveBeenCalledOnce();
+    expect(stream.start).not.toHaveBeenCalled();
+  });
+
+  it('falls back to start when reconnect fails', async () => {
+    await startWithCamera();
+    const stream = getStream();
+
+    // First token → normal start
+    tokenManager.emit('videoToken', 'cam-1', makeConfig());
+    await vi.advanceTimersByTimeAsync(0);
+
+    stream.state = 'streaming';
+    stream.start.mockClear();
+    stream.reconnect.mockRejectedValueOnce(new Error('reconnect failed'));
+
+    // Second token → reconnect fails, should fall back to start
+    tokenManager.emit('videoToken', 'cam-1', makeConfig());
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(stream.reconnect).toHaveBeenCalledOnce();
+    expect(stream.start).toHaveBeenCalledOnce();
+  });
+
+  it('uses start (not reconnect) when stream is in error state', async () => {
+    await startWithCamera();
+    const stream = getStream();
+
+    tokenManager.emit('videoToken', 'cam-1', makeConfig());
+    await vi.advanceTimersByTimeAsync(0);
+
+    stream.state = 'error';
+    stream.start.mockClear();
+
+    tokenManager.emit('videoToken', 'cam-1', makeConfig());
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(stream.reconnect).not.toHaveBeenCalled();
+    expect(stream.start).toHaveBeenCalledOnce();
   });
 
   it('does not retry when manager is stopped', async () => {

--- a/src/camera/camera-manager.ts
+++ b/src/camera/camera-manager.ts
@@ -85,6 +85,19 @@ export class CameraManager {
       return;
     }
 
+    // If the stream is already active, do a seamless reconnect (keeps ffmpeg alive)
+    if (stream.state === 'streaming') {
+      try {
+        log.info({ camera: stream.cameraName }, 'Seamless reconnect with fresh token');
+        await stream.reconnect(config);
+        this.failureCount.delete(cameraId);
+        return;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.warn({ camera: stream.cameraName }, 'Reconnect failed (%s), falling back to full restart', msg);
+      }
+    }
+
     this.activeStarts.add(cameraId);
 
     try {

--- a/src/camera/camera-manager.ts
+++ b/src/camera/camera-manager.ts
@@ -87,14 +87,17 @@ export class CameraManager {
 
     // If the stream is already active, do a seamless reconnect (keeps ffmpeg alive)
     if (stream.state === 'streaming') {
+      this.activeStarts.add(cameraId);
       try {
         log.info({ camera: stream.cameraName }, 'Seamless reconnect with fresh token');
         await stream.reconnect(config);
         this.failureCount.delete(cameraId);
+        this.activeStarts.delete(cameraId);
         return;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         log.warn({ camera: stream.cameraName }, 'Reconnect failed (%s), falling back to full restart', msg);
+        this.activeStarts.delete(cameraId);
       }
     }
 

--- a/src/camera/camera-stream.test.ts
+++ b/src/camera/camera-stream.test.ts
@@ -303,6 +303,7 @@ describe('CameraStream.reconnect', () => {
     }) as any);
 
     await expect(stream.reconnect(makeConfig())).rejects.toThrow('signaling failed');
+    expect(stream.state).toBe('error');
   });
 });
 

--- a/src/camera/camera-stream.test.ts
+++ b/src/camera/camera-stream.test.ts
@@ -44,6 +44,7 @@ vi.mock('../utils/retry.js', () => ({
 }));
 
 import { CameraStream } from './camera-stream.js';
+import { SignalingClient } from '../signaling/signaling-client.js';
 import { sleep } from '../utils/retry.js';
 
 const makeConfig = (): EndToEndWebrtcConfig => ({
@@ -185,6 +186,123 @@ describe('CameraStream.start', () => {
       .mockRejectedValueOnce(new Error('Camera has not yet dialed in'));
 
     await expect(stream.start(makeConfig(), refetchToken)).rejects.toThrow('auth expired');
+  });
+});
+
+describe('CameraStream.reconnect', () => {
+  let stream: CameraStream;
+
+  beforeEach(() => {
+    stream = new CameraStream('cam-123', 'test-camera', 'rtsp://localhost:8554');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function setupReconnectMocks(stream: CameraStream) {
+    // Stub internal methods that depend on werift mocks
+    vi.spyOn(stream as any, 'createPeerConnection').mockReturnValue({});
+    vi.spyOn(stream as any, 'setupPeerConnection').mockImplementation(() => {});
+    vi.spyOn(stream as any, 'registerPostSessionHandlers').mockImplementation(() => {});
+  }
+
+  function mockSignalingToSucceed() {
+    vi.mocked(SignalingClient).mockImplementation(() => ({
+      on: vi.fn((event: string, handler: any) => {
+        if (event === 'sessionStarted') setTimeout(handler, 0);
+      }),
+      removeAllListeners: vi.fn(),
+      close: vi.fn(),
+      connect: vi.fn().mockResolvedValue(undefined),
+      sendAnswer: vi.fn(),
+      sendIceCandidate: vi.fn(),
+    }) as any);
+  }
+
+  it('does not kill ffmpeg or videoSocket during reconnect', async () => {
+    const mockFfmpeg = { kill: vi.fn(), on: vi.fn() };
+    const mockSocket = { close: vi.fn(), send: vi.fn() };
+
+    (stream as any).ffmpeg = mockFfmpeg;
+    (stream as any).videoSocket = mockSocket;
+    (stream as any).videoPort = 12345;
+    (stream as any)._state = 'streaming';
+
+    setupReconnectMocks(stream);
+    mockSignalingToSucceed();
+
+    await stream.reconnect(makeConfig());
+
+    expect(mockFfmpeg.kill).not.toHaveBeenCalled();
+    expect(mockSocket.close).not.toHaveBeenCalled();
+  });
+
+  it('closes old PC during reconnect', async () => {
+    const mockPcClose = vi.fn().mockResolvedValue(undefined);
+    (stream as any).pc = { close: mockPcClose };
+    (stream as any).ffmpeg = { kill: vi.fn(), on: vi.fn() };
+    (stream as any).videoSocket = { close: vi.fn(), send: vi.fn() };
+    (stream as any).videoPort = 12345;
+    (stream as any)._state = 'streaming';
+
+    setupReconnectMocks(stream);
+    mockSignalingToSucceed();
+
+    await stream.reconnect(makeConfig());
+
+    expect(mockPcClose).toHaveBeenCalled();
+  });
+
+  it('sets state to connecting during reconnect', async () => {
+    (stream as any).ffmpeg = { kill: vi.fn(), on: vi.fn() };
+    (stream as any).videoSocket = { close: vi.fn(), send: vi.fn() };
+    (stream as any).videoPort = 12345;
+    (stream as any)._state = 'streaming';
+
+    let capturedState: string | undefined;
+
+    setupReconnectMocks(stream);
+
+    vi.mocked(SignalingClient).mockImplementation(() => ({
+      on: vi.fn((event: string, handler: any) => {
+        if (event === 'sessionStarted') {
+          capturedState = stream.state;
+          setTimeout(handler, 0);
+        }
+      }),
+      removeAllListeners: vi.fn(),
+      close: vi.fn(),
+      connect: vi.fn().mockResolvedValue(undefined),
+      sendAnswer: vi.fn(),
+      sendIceCandidate: vi.fn(),
+    }) as any);
+
+    await stream.reconnect(makeConfig());
+
+    expect(capturedState).toBe('connecting');
+  });
+
+  it('throws when signaling fails during reconnect', async () => {
+    (stream as any).ffmpeg = { kill: vi.fn(), on: vi.fn() };
+    (stream as any).videoSocket = { close: vi.fn(), send: vi.fn() };
+    (stream as any).videoPort = 12345;
+    (stream as any)._state = 'streaming';
+
+    setupReconnectMocks(stream);
+
+    vi.mocked(SignalingClient).mockImplementation(() => ({
+      on: vi.fn((event: string, handler: any) => {
+        if (event === 'error') setTimeout(() => handler(new Error('signaling failed')), 0);
+      }),
+      removeAllListeners: vi.fn(),
+      close: vi.fn(),
+      connect: vi.fn().mockResolvedValue(undefined),
+      sendAnswer: vi.fn(),
+      sendIceCandidate: vi.fn(),
+    }) as any);
+
+    await expect(stream.reconnect(makeConfig())).rejects.toThrow('signaling failed');
   });
 });
 

--- a/src/camera/camera-stream.ts
+++ b/src/camera/camera-stream.ts
@@ -93,6 +93,38 @@ export class CameraStream {
     throw new Error(`Camera ${this.cameraName} failed to dial in after ${MAX_DIAL_IN_RETRIES} attempts`);
   }
 
+  /**
+   * Reconnect WebRTC with a fresh token while keeping ffmpeg and the UDP
+   * socket alive.  Only the signaling WebSocket and RTCPeerConnection are
+   * rebuilt — the RTSP push to go2rtc is never interrupted.
+   */
+  async reconnect(config: EndToEndWebrtcConfig): Promise<void> {
+    log.info({ camera: this.cameraName }, 'Reconnecting WebRTC (keeping ffmpeg alive)...');
+
+    // Tear down token-bound resources only
+    this.signaling.removeAllListeners();
+    this.signaling.close();
+    if (this.pc) {
+      await this.pc.close().catch(() => {});
+      this.pc = null;
+    }
+
+    // Fresh signaling client
+    this.signaling = new SignalingClient(this.cameraName);
+    this._state = 'connecting';
+
+    // New peer connection
+    this.pc = this.createPeerConnection(config);
+    this.setupPeerConnection();
+
+    // Connect signaling
+    await this.connectSignaling(config);
+
+    log.info({ camera: this.cameraName }, 'Reconnect complete, waiting for SDP offer...');
+
+    this.registerPostSessionHandlers();
+  }
+
   /** Tear down the entire pipeline. */
   async stop(): Promise<void> {
     this.signaling.removeAllListeners();
@@ -131,7 +163,17 @@ export class CameraStream {
     this.videoPort = await this.allocateUdpPort();
     log.info({ camera: this.cameraName, videoPort: this.videoPort }, 'Allocated RTP port');
 
-    this.pc = new RTCPeerConnection({
+    this.pc = this.createPeerConnection(config);
+    this.setupPeerConnection();
+    await this.connectSignaling(config);
+
+    log.info({ camera: this.cameraName }, 'Session started, waiting for SDP offer...');
+
+    this.registerPostSessionHandlers();
+  }
+
+  private createPeerConnection(config: EndToEndWebrtcConfig): RTCPeerConnection {
+    return new RTCPeerConnection({
       iceServers: config.iceServers.flatMap((s) =>
         s.urls.map((url) => ({
           urls: url,
@@ -167,11 +209,11 @@ export class CameraStream {
         ],
       },
     });
+  }
 
-    this.setupPeerConnection();
-
-    // Connect signaling — resolve on SESSION_STARTED, reject on close/error
-    await new Promise<void>((resolve, reject) => {
+  /** Connect signaling — resolve on SESSION_STARTED, reject on close/error. */
+  private connectSignaling(config: EndToEndWebrtcConfig): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
       this.signaling.on('sessionStarted', () => resolve());
 
       this.signaling.on('closed', (_code, reason) => {
@@ -196,9 +238,10 @@ export class CameraStream {
         config.cameraAuthToken,
       ).catch(reject);
     });
+  }
 
-    log.info({ camera: this.cameraName }, 'Session started, waiting for SDP offer...');
-
+  /** Register SDP/ICE/close handlers after session is established. */
+  private registerPostSessionHandlers(): void {
     this.signaling.on('sdpOffer', async (offer) => {
       try {
         await this.handleSdpOffer(offer);
@@ -229,9 +272,11 @@ export class CameraStream {
       if (rtpSubscribed) return;
       rtpSubscribed = true;
 
-      // Start ffmpeg and create the send socket
+      // Start ffmpeg and create the send socket (guards allow reuse on reconnect)
       this.startFfmpeg();
-      this.videoSocket = createSocket('udp4');
+      if (!this.videoSocket) {
+        this.videoSocket = createSocket('udp4');
+      }
 
       track.onReceiveRtp.subscribe((rtp: any) => {
         if (this.videoSocket && this.videoPort) {

--- a/src/camera/camera-stream.ts
+++ b/src/camera/camera-stream.ts
@@ -99,6 +99,10 @@ export class CameraStream {
    * rebuilt — the RTSP push to go2rtc is never interrupted.
    */
   async reconnect(config: EndToEndWebrtcConfig): Promise<void> {
+    if (this._state !== 'streaming') {
+      throw new Error(`Cannot reconnect: expected 'streaming', got '${this._state}'`);
+    }
+
     log.info({ camera: this.cameraName }, 'Reconnecting WebRTC (keeping ffmpeg alive)...');
 
     // Tear down token-bound resources only
@@ -113,12 +117,14 @@ export class CameraStream {
     this.signaling = new SignalingClient(this.cameraName);
     this._state = 'connecting';
 
-    // New peer connection
-    this.pc = this.createPeerConnection(config);
-    this.setupPeerConnection();
-
-    // Connect signaling
-    await this.connectSignaling(config);
+    try {
+      this.pc = this.createPeerConnection(config);
+      this.setupPeerConnection();
+      await this.connectSignaling(config);
+    } catch (err) {
+      this._state = 'error';
+      throw err;
+    }
 
     log.info({ camera: this.cameraName }, 'Reconnect complete, waiting for SDP offer...');
 
@@ -356,6 +362,7 @@ export class CameraStream {
     });
 
     pc.connectionStateChange.subscribe((state) => {
+      if (pc !== this.pc) return; // stale PC during reconnect
       log.info({ camera: this.cameraName, connectionState: state }, 'Connection state changed');
       if (state === 'failed' || state === 'disconnected') {
         this._state = 'error';


### PR DESCRIPTION
## Summary

- Keeps ffmpeg and the UDP socket alive during 10-minute token refreshes
- Only tears down and rebuilds the signaling WebSocket and RTCPeerConnection (which are bound to the token)
- New `reconnect()` method on `CameraStream` swaps the WebRTC connection while the RTSP push to go2rtc continues uninterrupted
- `CameraManager` uses `reconnect()` when a stream is already active, falls back to full `start()` if reconnect fails
- Refactored `tryConnect()` into shared helpers (`createPeerConnection`, `connectSignaling`, `registerPostSessionHandlers`) used by both `tryConnect()` and `reconnect()`

## Why

Every 10 minutes, the token refresh tears down the entire pipeline including ffmpeg. When ffmpeg restarts, Homebridge joins mid-GOP and gets a corrupt first I-frame. HKSV sees massive concealment errors (1000-8000 macroblocks) and terminates every recording with reason 6 (STREAM FORMAT INCOMPATIBILITY).

Closes #10

## Test plan

1. 7 new tests across `camera-stream.test.ts` and `camera-manager.test.ts`
2. Deploy and monitor logs for 30+ minutes
3. Confirm no ffmpeg restarts during token refresh
4. Confirm no I-frame concealment errors at 10-minute boundaries in Homebridge logs
5. Confirm HKSV recordings no longer terminate with reason 6