### PR TITLE
Subscribe to the registered WebRTC track, not the placeholder

### DIFF
--- a/src/camera/camera-stream.test.ts
+++ b/src/camera/camera-stream.test.ts
@@ -315,6 +315,67 @@ describe('CameraStream.reconnect', () => {
   });
 });
 
+describe('CameraStream RTP track selection', () => {
+  const event = () => {
+    const handlers: Array<(...args: any[]) => void> = [];
+    return {
+      subscribe: vi.fn((handler: (...args: any[]) => void) => {
+        handlers.push(handler);
+      }),
+      emit: (...args: any[]) => {
+        for (const handler of handlers) handler(...args);
+      },
+    };
+  };
+
+  it('ignores werift placeholder tracks and forwards RTP from the registered onTrack track', () => {
+    const stream = new CameraStream('cam-123', 'test-camera', 'rtsp://localhost:8554');
+    const placeholderRtp = event();
+    const actualRtp = event();
+    const placeholderTrack = { kind: 'video', onReceiveRtp: placeholderRtp };
+    const actualTrack = { kind: 'video', onReceiveRtp: actualRtp };
+    const onRemoteTransceiverAdded = event();
+    const onTrack = event();
+    const connectionStateChange = event();
+    const pc = {
+      onRemoteTransceiverAdded,
+      onTrack,
+      ontrack: null,
+      connectionStateChange,
+      onIceCandidate: event(),
+      iceConnectionStateChange: event(),
+      iceGatheringStateChange: event(),
+      getTransceivers: vi.fn().mockReturnValue([]),
+    };
+    const startFfmpeg = vi.spyOn(stream as any, 'startFfmpeg').mockImplementation(() => {});
+
+    (stream as any).pc = pc;
+    (stream as any).videoPort = 12345;
+    (stream as any).setupPeerConnection();
+
+    onRemoteTransceiverAdded.emit({
+      mid: 'video0',
+      kind: 'video',
+      direction: 'recvonly',
+      receiver: { track: placeholderTrack },
+    });
+    expect(startFfmpeg).not.toHaveBeenCalled();
+
+    onTrack.emit(actualTrack);
+    expect(startFfmpeg).toHaveBeenCalledOnce();
+
+    const packet = { serialize: vi.fn().mockReturnValue(Buffer.from([1, 2, 3])) };
+    actualRtp.emit(packet);
+
+    expect((stream as any).videoSocket.send).toHaveBeenCalledWith(
+      Buffer.from([1, 2, 3]),
+      12345,
+      '127.0.0.1',
+    );
+    expect(packet.serialize).toHaveBeenCalledOnce();
+  });
+});
+
 describe('CameraStream ffmpeg mid-stream exit recovery', () => {
   let stream: CameraStream;
   let exitHandler: (code: number | null) => void;

--- a/src/camera/camera-stream.ts
+++ b/src/camera/camera-stream.ts
@@ -301,19 +301,20 @@ export class CameraStream {
       log.info({ camera: this.cameraName, source }, 'Video streaming active');
     };
 
-    // Method 1: onRemoteTransceiverAdded — earliest possible, receiver may not exist yet
+    // onRemoteTransceiverAdded fires before werift has registered the remote
+    // SSRC-backed track. At that point receiver.track can be a placeholder
+    // defaultTrack which never receives RTP. Observe it for diagnostics, but
+    // wait for onTrack before subscribing so the real track wins the guard.
     pc.onRemoteTransceiverAdded.subscribe((transceiver) => {
       log.info(
         { camera: this.cameraName, mid: transceiver.mid, kind: transceiver.kind, direction: transceiver.direction,
           hasReceiver: !!transceiver.receiver, hasTrack: !!transceiver.receiver?.track },
         'Remote transceiver added',
       );
-      if (transceiver.kind === 'video' && transceiver.receiver?.track) {
-        subscribeToRtp(transceiver.receiver.track, 'onRemoteTransceiverAdded');
-      }
     });
 
-    // Method 2: onTrack — standard event
+    // Method 1: onTrack — werift emits this after it registers the actual
+    // remote media track and routes the negotiated SSRC to it.
     pc.onTrack.subscribe((track) => {
       log.info({ camera: this.cameraName, kind: track.kind }, 'onTrack fired');
       if (track.kind === 'video') {
@@ -321,7 +322,7 @@ export class CameraStream {
       }
     });
 
-    // Method 3: ontrack callback — alternative style
+    // Method 2: ontrack callback — alternative style
     pc.ontrack = (ev) => {
       log.info({ camera: this.cameraName, kind: ev.track.kind }, 'ontrack callback fired');
       if (ev.track.kind === 'video') {
@@ -329,7 +330,7 @@ export class CameraStream {
       }
     };
 
-    // Method 4: When connected, scan transceivers as last resort
+    // Method 3: When connected, scan transceivers as last resort
     pc.connectionStateChange.subscribe((state) => {
       if (state !== 'connected') return;
       log.info({ camera: this.cameraName }, 'Connection connected, scanning transceivers');


### PR DESCRIPTION
## Problem

A camera could complete signalling and reach a `connected` PeerConnection while never delivering a single RTP packet. The stream sits silent, `state` stays where it was, and **nothing errors** — so there is no log line pointing at the cause.

## Cause

`onRemoteTransceiverAdded` fires *before* werift has registered the remote SSRC-backed track. At that moment `transceiver.receiver.track` is a placeholder `defaultTrack` which never receives media.

`subscribeToRtp()` is guarded by a one-shot `rtpSubscribed` flag. Subscribing from `onRemoteTransceiverAdded` means the **placeholder wins that guard** — and when werift later emits `onTrack` with the real track, the guard rejects it. RTP is then routed to an object nobody is subscribed to.

## Fix

Stop subscribing from `onRemoteTransceiverAdded`. The handler is kept for its diagnostics, which are genuinely useful for this class of problem, but `onTrack` now claims the guard so the real track wins. The remaining fallbacks (`ontrack` callback, transceiver scan on `connected`) are unchanged.

## Testing

Adds regression coverage for the placeholder-then-real-track ordering. Full suite passes (9 files / 109 tests).

---

Found while running this bridge as a long-lived deployment. A companion PR for a second, related lifecycle bug is stacked on this branch and will follow.