### PR TITLE
Ignore stale ffmpeg exits so healthy streams are not torn down

### DIFF
--- a/src/camera/camera-stream.test.ts
+++ b/src/camera/camera-stream.test.ts
@@ -436,6 +436,47 @@ describe('CameraStream ffmpeg mid-stream exit recovery', () => {
 
     expect(stream.state).toBe('idle');
   });
+
+  it('ignores a late exit from an intentionally stopped ffmpeg process', async () => {
+    const callback = vi.fn();
+    stream.onUnexpectedExit = callback;
+
+    const ffmpeg = (stream as any).ffmpeg;
+    ffmpeg.kill.mockImplementation(() => exitHandler(0));
+
+    await stream.stop();
+
+    expect(ffmpeg.kill).toHaveBeenCalledWith('SIGTERM');
+    expect((stream as any).ffmpeg).toBeNull();
+    expect(stream.state).toBe('idle');
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('does not clear or restart a replacement when an older ffmpeg exits', async () => {
+    const callback = vi.fn();
+    stream.onUnexpectedExit = callback;
+    const staleExitHandler = exitHandler;
+
+    const { spawn } = await import('node:child_process');
+    const replacement = {
+      stdin: { write: vi.fn(), end: vi.fn() },
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn(),
+      kill: vi.fn(),
+    } as any;
+    vi.mocked(spawn).mockReturnValue(replacement);
+
+    (stream as any).ffmpeg = null;
+    (stream as any).startFfmpeg();
+    expect((stream as any).ffmpeg).toBe(replacement);
+
+    staleExitHandler(0);
+
+    expect((stream as any).ffmpeg).toBe(replacement);
+    expect(stream.state).toBe('streaming');
+    expect(callback).not.toHaveBeenCalled();
+  });
 });
 
 describe('CameraStream ffmpeg SDP', () => {

--- a/src/camera/camera-stream.test.ts
+++ b/src/camera/camera-stream.test.ts
@@ -315,6 +315,67 @@ describe('CameraStream.reconnect', () => {
   });
 });
 
+describe('CameraStream RTP track selection', () => {
+  const event = () => {
+    const handlers: Array<(...args: any[]) => void> = [];
+    return {
+      subscribe: vi.fn((handler: (...args: any[]) => void) => {
+        handlers.push(handler);
+      }),
+      emit: (...args: any[]) => {
+        for (const handler of handlers) handler(...args);
+      },
+    };
+  };
+
+  it('ignores werift placeholder tracks and forwards RTP from the registered onTrack track', () => {
+    const stream = new CameraStream('cam-123', 'test-camera', 'rtsp://localhost:8554');
+    const placeholderRtp = event();
+    const actualRtp = event();
+    const placeholderTrack = { kind: 'video', onReceiveRtp: placeholderRtp };
+    const actualTrack = { kind: 'video', onReceiveRtp: actualRtp };
+    const onRemoteTransceiverAdded = event();
+    const onTrack = event();
+    const connectionStateChange = event();
+    const pc = {
+      onRemoteTransceiverAdded,
+      onTrack,
+      ontrack: null,
+      connectionStateChange,
+      onIceCandidate: event(),
+      iceConnectionStateChange: event(),
+      iceGatheringStateChange: event(),
+      getTransceivers: vi.fn().mockReturnValue([]),
+    };
+    const startFfmpeg = vi.spyOn(stream as any, 'startFfmpeg').mockImplementation(() => {});
+
+    (stream as any).pc = pc;
+    (stream as any).videoPort = 12345;
+    (stream as any).setupPeerConnection();
+
+    onRemoteTransceiverAdded.emit({
+      mid: 'video0',
+      kind: 'video',
+      direction: 'recvonly',
+      receiver: { track: placeholderTrack },
+    });
+    expect(startFfmpeg).not.toHaveBeenCalled();
+
+    onTrack.emit(actualTrack);
+    expect(startFfmpeg).toHaveBeenCalledOnce();
+
+    const packet = { serialize: vi.fn().mockReturnValue(Buffer.from([1, 2, 3])) };
+    actualRtp.emit(packet);
+
+    expect((stream as any).videoSocket.send).toHaveBeenCalledWith(
+      Buffer.from([1, 2, 3]),
+      12345,
+      '127.0.0.1',
+    );
+    expect(packet.serialize).toHaveBeenCalledOnce();
+  });
+});
+
 describe('CameraStream ffmpeg mid-stream exit recovery', () => {
   let stream: CameraStream;
   let exitHandler: (code: number | null) => void;

--- a/src/camera/camera-stream.ts
+++ b/src/camera/camera-stream.ts
@@ -142,8 +142,12 @@ export class CameraStream {
     }
 
     if (this.ffmpeg) {
-      this.ffmpeg.kill('SIGTERM');
+      // Detach ownership before signaling the child. The exit event may be
+      // delivered after a replacement ffmpeg has already started; that stale
+      // event must not clear the replacement or trigger stream recovery.
+      const ffmpeg = this.ffmpeg;
       this.ffmpeg = null;
+      ffmpeg.kill('SIGTERM');
     }
 
     if (this.videoSocket) {
@@ -464,13 +468,14 @@ export class CameraStream {
     ];
 
     log.info({ camera: this.cameraName, rtspUrl }, 'Starting ffmpeg');
-    this.ffmpeg = spawn('ffmpeg', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    const ffmpeg = spawn('ffmpeg', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    this.ffmpeg = ffmpeg;
 
     // Write the SDP to ffmpeg's stdin, then close it
-    this.ffmpeg.stdin?.write(sdp);
-    this.ffmpeg.stdin?.end();
+    ffmpeg.stdin?.write(sdp);
+    ffmpeg.stdin?.end();
 
-    this.ffmpeg.stderr?.on('data', (data: Buffer) => {
+    ffmpeg.stderr?.on('data', (data: Buffer) => {
       const line = data.toString().trim();
       if (!line) return;
       // ffmpeg progress lines are noisy once streaming is established
@@ -482,7 +487,15 @@ export class CameraStream {
       }
     });
 
-    this.ffmpeg.on('exit', (code) => {
+    ffmpeg.on('exit', (code) => {
+      // Ignore an intentionally stopped or superseded child. Without this
+      // identity check, a late exit from the old process can erase the
+      // current process reference and restart an otherwise healthy stream.
+      if (this.ffmpeg !== ffmpeg) {
+        log.debug({ camera: this.cameraName, code }, 'Ignoring stale ffmpeg exit');
+        return;
+      }
+
       log.warn({ camera: this.cameraName, code }, 'ffmpeg exited');
       this.ffmpeg = null;
 

--- a/src/camera/camera-stream.ts
+++ b/src/camera/camera-stream.ts
@@ -301,19 +301,20 @@ export class CameraStream {
       log.info({ camera: this.cameraName, source }, 'Video streaming active');
     };
 
-    // Method 1: onRemoteTransceiverAdded — earliest possible, receiver may not exist yet
+    // onRemoteTransceiverAdded fires before werift has registered the remote
+    // SSRC-backed track. At that point receiver.track can be a placeholder
+    // defaultTrack which never receives RTP. Observe it for diagnostics, but
+    // wait for onTrack before subscribing so the real track wins the guard.
     pc.onRemoteTransceiverAdded.subscribe((transceiver) => {
       log.info(
         { camera: this.cameraName, mid: transceiver.mid, kind: transceiver.kind, direction: transceiver.direction,
           hasReceiver: !!transceiver.receiver, hasTrack: !!transceiver.receiver?.track },
         'Remote transceiver added',
       );
-      if (transceiver.kind === 'video' && transceiver.receiver?.track) {
-        subscribeToRtp(transceiver.receiver.track, 'onRemoteTransceiverAdded');
-      }
     });
 
-    // Method 2: onTrack — standard event
+    // Method 1: onTrack — werift emits this after it registers the actual
+    // remote media track and routes the negotiated SSRC to it.
     pc.onTrack.subscribe((track) => {
       log.info({ camera: this.cameraName, kind: track.kind }, 'onTrack fired');
       if (track.kind === 'video') {
@@ -321,7 +322,7 @@ export class CameraStream {
       }
     });
 
-    // Method 3: ontrack callback — alternative style
+    // Method 2: ontrack callback — alternative style
     pc.ontrack = (ev) => {
       log.info({ camera: this.cameraName, kind: ev.track.kind }, 'ontrack callback fired');
       if (ev.track.kind === 'video') {
@@ -329,7 +330,7 @@ export class CameraStream {
       }
     };
 
-    // Method 4: When connected, scan transceivers as last resort
+    // Method 3: When connected, scan transceivers as last resort
     pc.connectionStateChange.subscribe((state) => {
       if (state !== 'connected') return;
       log.info({ camera: this.cameraName }, 'Connection connected, scanning transceivers');


### PR DESCRIPTION
> ⚠️ **Stacked on #23.** This branch contains that commit as its base, so the diff here shows both. Review/merge #23 first and this reduces to a single commit.

## Problem

On a long-running deployment, healthy WebRTC sessions were torn down every **~35–40 seconds**. go2rtc accumulated **two publishers** for one stream and **248 stuck consumers**, and HomeKit live view became unreliable.

## Cause

A race between an exiting ffmpeg child and its replacement.

When a stream is stopped or superseded, the old child's `exit` event can be delivered *after* the new child has already been assigned to `this.ffmpeg`. The handler closed over `this` only, so it had no way to tell **which** process had died. It therefore:

1. nulled out the reference to the **replacement**, and
2. saw `_state === 'streaming'` and fired `onUnexpectedExit()`

— tearing down a session that was working fine. Recovery then started another publisher, which is how two accumulate.

The telltale in the logs is an exiting ffmpeg reporting ~37s elapsed while the currently referenced process started ~20s earlier.

## Fix

Two halves, and **both** are required:

1. `stop()` detaches ownership *before* `SIGTERM`, so the kill it initiates can never match the live reference.
2. `startFfmpeg()` captures the child in a local, and the `exit` handler returns early unless `this.ffmpeg === ffmpeg`.

Capturing the child in the closure is what makes the identity check possible at all — `this.ffmpeg` alone cannot tell you which process exited.

## Testing

Adds regression coverage for both orderings: a synchronous exit during an intentional stop, and a late exit arriving after a replacement has started. Full suite passes (9 files / 111 tests).

## Note

This and #23 are the same class of defect — a reference held without asking *which* instance it points to. #23 is a placeholder track winning a guard the real track needed; this is a dead process's callback mutating state belonging to its replacement. Worth a look at other lifecycle-managed handles with that lens.