### PR TITLE
Harden the network layer: enforce WSS, bound handshakes, stop logging payloads

### DIFF
--- a/src/auth/alarm-auth.ts
+++ b/src/auth/alarm-auth.ts
@@ -14,6 +14,7 @@ const CAMERAS_URL = 'https://www.alarm.com/web/api/video/devices/cameras';
 export class AlarmAuth {
   private auth: AuthOpts | null = null;
   private lastLoginAt = 0;
+  private authenticateInFlight: Promise<void> | null = null;
 
   constructor(
     private readonly username: string,
@@ -31,13 +32,27 @@ export class AlarmAuth {
 
   /** Force a fresh login. */
   async authenticate(): Promise<void> {
+    if (this.authenticateInFlight) return this.authenticateInFlight;
+
+    this.authenticateInFlight = this.performAuthentication();
+    try {
+      await this.authenticateInFlight;
+    } finally {
+      this.authenticateInFlight = null;
+    }
+  }
+
+  private async performAuthentication(): Promise<void> {
     log.info('Logging in to Alarm.com...');
     this.auth = await retry(
       () => login(this.username, this.password, this.mfaToken),
       { maxAttempts: 3, label: 'login' },
     );
     this.lastLoginAt = Date.now();
-    log.info({ systems: this.auth.systems }, 'Login successful');
+    const systemCount = Array.isArray(this.auth.systems)
+      ? this.auth.systems.length
+      : Object.keys(this.auth.systems ?? {}).length;
+    log.info({ systemCount }, 'Login successful');
   }
 
   /** Check if session is likely still valid (logged in < 55 minutes ago). */

--- a/src/auth/token-manager.ts
+++ b/src/auth/token-manager.ts
@@ -130,16 +130,36 @@ export class TokenManager extends EventEmitter {
 
     const topAttrs = body?.data?.attributes ?? {};
     const iceServersRaw = topAttrs.iceServers;
-    const iceServers = iceServersRaw ? JSON.parse(iceServersRaw) : [];
+    let iceServers: EndToEndWebrtcConfig['iceServers'] = [];
+    if (Array.isArray(iceServersRaw)) {
+      iceServers = iceServersRaw;
+    } else if (typeof iceServersRaw === 'string' && iceServersRaw) {
+      try {
+        const parsed = JSON.parse(iceServersRaw);
+        if (Array.isArray(parsed)) iceServers = parsed;
+      } catch {
+        throw new Error('Alarm.com returned invalid ICE server configuration');
+      }
+    }
 
     const included: any[] = body?.included ?? [];
     const e2eInfo = included.find(
       (inc: any) => inc.type === 'video/videoSources/endToEndWebrtcConnectionInfo',
     );
 
-    if (!e2eInfo) return null;
+    if (!e2eInfo?.attributes) return null;
 
     const attrs = e2eInfo.attributes;
+    if (
+      typeof attrs.signallingServerUrl !== 'string' ||
+      typeof attrs.signallingServerToken !== 'string' ||
+      typeof attrs.cameraAuthToken !== 'string' ||
+      !attrs.signallingServerUrl ||
+      !attrs.signallingServerToken ||
+      !attrs.cameraAuthToken
+    ) {
+      throw new Error('Alarm.com returned incomplete end-to-end WebRTC configuration');
+    }
     return {
       signallingServerUrl: attrs.signallingServerUrl,
       signallingServerToken: attrs.signallingServerToken,

--- a/src/camera/camera-stream.ts
+++ b/src/camera/camera-stream.ts
@@ -258,7 +258,7 @@ export class CameraStream {
     });
 
     this.signaling.on('iceCandidate', async (candidate) => {
-      log.info({ camera: this.cameraName, candidate: candidate.candidate }, 'Remote ICE candidate');
+      log.debug({ camera: this.cameraName }, 'Remote ICE candidate received');
       await this.handleRemoteIceCandidate(candidate);
     });
 
@@ -345,7 +345,8 @@ export class CameraStream {
     });
 
     pc.onIceCandidate.subscribe((candidate) => {
-      log.info({ camera: this.cameraName, candidate: candidate.candidate }, 'Local ICE candidate');
+      if (!candidate) return;
+      log.debug({ camera: this.cameraName }, 'Local ICE candidate generated');
       this.signaling.sendIceCandidate({
         candidate: candidate.candidate,
         sdpMid: candidate.sdpMid ?? null,

--- a/src/events/alarm-event-listener.test.ts
+++ b/src/events/alarm-event-listener.test.ts
@@ -91,7 +91,23 @@ describe('AlarmEventListener reconnection', () => {
 
     expect(auth.get).toHaveBeenCalledTimes(1);
     expect(getInstances()).toHaveLength(1);
-    expect(getInstances()[0].url).toBe('wss://events.alarm.com?auth=ws-token-123');
+    expect(getInstances()[0].url).toBe('wss://events.alarm.com/?auth=ws-token-123');
+  });
+
+  it('sends a querystring-shaped token verbatim, without re-encoding it', async () => {
+    // Real Alarm.com WebSocket tokens are not opaque blobs: they are ~600 chars
+    // of already-URL-encoded querystring, containing %XX escapes, & separators
+    // and = assignments. Encoding them a second time turns every % into %25 and
+    // every & into %26, and the server rejects the handshake with HTTP 401.
+    const encodedToken = 'ln%3Dus%40example.net&sig=Zm9v%2Fbar%3D&t=1234';
+    auth.get.mockResolvedValue({
+      value: encodedToken,
+      metaData: { endpoint: 'wss://events.alarm.com' },
+    });
+
+    await listener.start();
+
+    expect(getInstances()[0].url).toBe(`wss://events.alarm.com/?auth=${encodedToken}`);
   });
 
   it('reconnects immediately on code 1008 (token expired)', async () => {

--- a/src/events/alarm-event-listener.ts
+++ b/src/events/alarm-event-listener.ts
@@ -83,8 +83,19 @@ export class AlarmEventListener extends EventEmitter {
         throw new Error('Invalid WebSocket token response');
       }
 
-      const wsUrl = `${endpoint}?auth=${token}`;
-      this.ws = new WebSocket(wsUrl);
+      const wsUrl = new URL(endpoint);
+      if (wsUrl.protocol !== 'wss:') {
+        throw new Error('Alarm.com event endpoint must use an encrypted WSS connection');
+      }
+      // Assign the raw query rather than using searchParams.set(). The token is
+      // already a URL-encoded querystring (~600 chars of %XX escapes, & and =),
+      // so encoding it a second time turns every % into %25 and Alarm.com
+      // rejects the handshake with HTTP 401.
+      wsUrl.search = `auth=${token}`;
+      this.ws = new WebSocket(wsUrl.toString(), {
+        handshakeTimeout: 30_000,
+        maxPayload: 1024 * 1024,
+      });
 
       this.ws.on('open', () => {
         log.info('WebSocket connected to %s', endpoint);
@@ -164,7 +175,7 @@ export class AlarmEventListener extends EventEmitter {
     try {
       msg = JSON.parse(raw);
     } catch {
-      log.warn('Non-JSON message: %s', raw.slice(0, 200));
+      log.warn({ messageLength: raw.length }, 'Non-JSON event message');
       return;
     }
 

--- a/src/go2rtc/go2rtc-api.ts
+++ b/src/go2rtc/go2rtc-api.ts
@@ -12,7 +12,9 @@ export class Go2rtcApi {
   /** Check if go2rtc is reachable. */
   async isHealthy(): Promise<boolean> {
     try {
-      const res = await fetch(`${this.baseUrl}/api/streams`);
+      const res = await fetch(`${this.baseUrl}/api/streams`, {
+        signal: AbortSignal.timeout(5_000),
+      });
       return res.ok;
     } catch {
       return false;
@@ -21,7 +23,9 @@ export class Go2rtcApi {
 
   /** Get the list of active streams. */
   async getStreams(): Promise<Record<string, unknown>> {
-    const res = await fetch(`${this.baseUrl}/api/streams`);
+    const res = await fetch(`${this.baseUrl}/api/streams`, {
+      signal: AbortSignal.timeout(5_000),
+    });
     if (!res.ok) throw new Error(`go2rtc API error: ${res.status}`);
     return res.json() as Promise<Record<string, unknown>>;
   }

--- a/src/signaling/signaling-client.ts
+++ b/src/signaling/signaling-client.ts
@@ -56,11 +56,24 @@ export class SignalingClient extends EventEmitter {
     }
 
     this.state = 'connecting';
-    const wsUrl = `${signallingServerUrl}/${signallingServerToken}`;
+    let baseUrl: URL;
+    try {
+      baseUrl = new URL(signallingServerUrl);
+    } catch {
+      throw new Error('Alarm.com returned an invalid signaling server URL');
+    }
+    if (baseUrl.protocol !== 'wss:') {
+      throw new Error('Alarm.com signaling must use an encrypted WSS connection');
+    }
+
+    const wsUrl = `${signallingServerUrl.replace(/\/$/, '')}/${signallingServerToken}`;
     log.info({ camera: this.cameraName }, 'Connecting to signaling server...');
 
     return new Promise<void>((resolve, reject) => {
-      this.ws = new WebSocket(wsUrl);
+      this.ws = new WebSocket(wsUrl, {
+        handshakeTimeout: 30_000,
+        maxPayload: 1024 * 1024,
+      });
 
       const timeout = setTimeout(() => {
         reject(new Error('Signaling connection timeout (30s)'));
@@ -168,14 +181,19 @@ export class SignalingClient extends EventEmitter {
     try {
       data = JSON.parse(msg);
     } catch {
-      log.warn({ camera: this.cameraName, msg }, 'Unrecognized message');
+      log.warn({ camera: this.cameraName, messageLength: msg.length }, 'Unrecognized message');
+      return;
+    }
+
+    if (!data || typeof data !== 'object') {
+      log.warn({ camera: this.cameraName }, 'Unexpected signaling message type');
       return;
     }
 
     if (data.sdp?.type === 'offer') {
       this.remoteId = data.from;
       this.localId = data.to;
-      log.info({ camera: this.cameraName, from: this.remoteId }, 'Received SDP offer');
+      log.info({ camera: this.cameraName }, 'Received SDP offer');
       this.emit('sdpOffer', data.sdp as RTCSessionDescriptionLike, data.from, data.to);
       return;
     }
@@ -186,7 +204,10 @@ export class SignalingClient extends EventEmitter {
       return;
     }
 
-    log.debug({ camera: this.cameraName, data }, 'Unhandled JSON message');
+    log.debug(
+      { camera: this.cameraName, keys: Object.keys(data).slice(0, 20) },
+      'Unhandled JSON message',
+    );
   }
 }
 


### PR DESCRIPTION
Everything that talks to Alarm.com or go2rtc, hardened. Verified against this repo's own dependency tree (`npm ci` from `main`'s lockfile): builds clean, 9 test files / 109 tests pass.

## Enforce encrypted transport

Both the signalling and event WebSocket URLs arrive from an API response and were used without validation. They're now parsed and rejected unless `wss:`, so a malformed or downgraded endpoint fails closed instead of silently connecting in the clear.

## Bound every remote interaction

| | before | after |
|---|---|---|
| WebSocket handshake | unbounded | `handshakeTimeout: 30_000` |
| WebSocket frame size | unbounded | `maxPayload: 1 MiB` |
| go2rtc HTTP calls | unbounded | `AbortSignal.timeout(5_000)` |

A hung endpoint otherwise parks a connection indefinitely, and a malfunctioning one can stream unbounded frames into memory.

## Stop logging network payloads

Raw signalling messages, ICE candidates, account system objects and peer IDs were being logged at `info`. Those describe the account's topology and, for ICE candidates, its internal addressing. Now logs lengths and key names rather than contents.

---

## Two things worth review attention

**1. The event WebSocket token is appended via `url.search =`, not `URLSearchParams.set()`.** This is deliberate and load-bearing.

The ADC websocket token is **~600 characters of already-URL-encoded querystring** — it contains `%XX` escapes, `&` separators and `=` assignments. `URLSearchParams.set()` encodes it a second time, turning every `%` into `%25` and every `&` into `%26`, producing a URL ~45 characters longer than it should be. Alarm.com cannot decode that and rejects the handshake with **HTTP 401**.

The safe-looking API is the wrong one here, and the failure is quiet: `auth.get()` returns a perfectly valid token every time, so the logs show `WebSocket error` and never `Failed to connect`. Worth a comment surviving any future refactor.

**2. `camera-stream.ts` gains `if (!candidate) return;` — and this matters for #17.**

Unrelated to the logging change: **werift 0.24 made the local ICE candidate callback nullable**, so `camera-stream.ts` does not typecheck against it. Since Dependabot **#17** proposes exactly that bump, merging #17 without this guard breaks the build. Verified: pristine `main` compiles against werift 0.19.9 and fails against 0.24.2.

---

⚠️ Touches `src/camera/camera-stream.ts`, which #23 and #24 also touch. Whichever merges last will need a trivial rebase — the changes are in different functions.