### PR TITLE
Redact credentials in logs, make the level configurable, shut down cleanly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import { loadConfig } from './config.js';
-import { logger } from './utils/logger.js';
+import { createChildLogger, setLogLevel } from './utils/logger.js';
 import { AlarmAuth } from './auth/alarm-auth.js';
 import { TokenManager } from './auth/token-manager.js';
 import { CameraManager } from './camera/camera-manager.js';
 import { Go2rtcApi } from './go2rtc/go2rtc-api.js';
 import { AlarmEventListener } from './events/alarm-event-listener.js';
 
-const log = logger.child({ component: 'main' });
+const log = createChildLogger('main');
 
 async function main(): Promise<void> {
   log.info('adc-video-bridge starting');
@@ -18,6 +18,8 @@ async function main(): Promise<void> {
     log.fatal('Config error: %s', err instanceof Error ? err.message : String(err));
     process.exit(1);
   }
+
+  setLogLevel(config.logging.level);
 
   log.info({ cameraCount: config.cameras.length }, 'Config loaded');
 
@@ -61,9 +63,11 @@ async function main(): Promise<void> {
     const sendMotionToggle = async (hbName: string) => {
       const url = `${motionUrl}/motion?${encodeURIComponent(hbName)}`;
       try {
-        const res = await fetch(url);
-        const body = await res.json() as { error: boolean; message: string };
-        log.info({ camera: hbName, response: body.message }, 'Motion webhook sent');
+        const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        log.info({ camera: hbName, status: res.status }, 'Motion webhook sent');
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         log.warn({ camera: hbName }, 'Motion webhook failed: %s', msg);
@@ -97,8 +101,13 @@ async function main(): Promise<void> {
   }
 
   // Graceful shutdown
+  let shutdownStarted = false;
+  let statusTimer: ReturnType<typeof setInterval> | null = null;
   const shutdown = async (signal: string) => {
+    if (shutdownStarted) return;
+    shutdownStarted = true;
     log.info({ signal }, 'Shutting down...');
+    if (statusTimer) clearInterval(statusTimer);
     eventListener.stop();
     await cameraManager.stop();
     auth.destroy();
@@ -113,7 +122,7 @@ async function main(): Promise<void> {
   await cameraManager.start(config.cameras);
 
   // Periodic status logging
-  setInterval(() => {
+  statusTimer = setInterval(() => {
     const status = cameraManager.getStatus();
     log.info({ streams: status }, 'Stream status');
   }, 60_000);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,7 +1,30 @@
 import pino from 'pino';
 
+const childLoggers: pino.Logger[] = [];
+
 export const logger = pino({
   level: process.env.LOG_LEVEL || 'info',
+  redact: {
+    paths: [
+      'password',
+      '*.password',
+      'token',
+      '*.token',
+      'signallingServerToken',
+      '*.signallingServerToken',
+      'cameraAuthToken',
+      '*.cameraAuthToken',
+      'credential',
+      '*.credential',
+      'authorization',
+      '*.authorization',
+      'cookie',
+      '*.cookie',
+      'ajaxKey',
+      '*.ajaxKey',
+    ],
+    censor: '[REDACTED]',
+  },
   transport:
     process.env.NODE_ENV !== 'production'
       ? { target: 'pino-pretty', options: { colorize: true } }
@@ -9,5 +32,12 @@ export const logger = pino({
 });
 
 export function createChildLogger(name: string) {
-  return logger.child({ component: name });
+  const child = logger.child({ component: name });
+  childLoggers.push(child);
+  return child;
+}
+
+export function setLogLevel(level: string): void {
+  logger.level = level;
+  for (const child of childLoggers) child.level = level;
 }


### PR DESCRIPTION
Three fixes to the entry point and the logger. Verified against this repo's own lockfile: builds clean, tests pass.

## Redact credentials in logs

pino gets a `redact` path list covering `password`, `token`, `signallingServerToken`, `cameraAuthToken`, `credential`, `authorization`, `cookie` and `ajaxKey` — at top level and one level down, censored to `[REDACTED]`.

Previously any of those reaching a log call was written in full. Several do: whole config objects and API responses get logged during setup, and the video-token response carries `signallingServerToken` and `cameraAuthToken` directly.

## The log level was read and then ignored

`config.logging.level` was parsed from config and never applied — the logger is constructed at import time, before config is loaded, so it kept its fixed level for the process lifetime. Setting `level: debug` in `config.yaml` did nothing.

Child loggers are now tracked so `setLogLevel()` can apply the configured level to all of them once config is available.

## Shut down once, and cleanly

- The `SIGINT`/`SIGTERM` handler could run twice if both arrived — now guarded by a `shutdownStarted` flag.
- The status interval was never cleared, so the process kept logging status after teardown began — now cleared.

## Bounded motion webhook

`AbortSignal.timeout(10_000)` plus an `res.ok` check. It previously awaited `res.json()` unconditionally, so a non-JSON error page (a proxy 502, say) threw inside the handler instead of reporting the HTTP status.

---

Part of a series splitting a large hardening change into reviewable pieces. Independent of #28 — no overlapping files.