### PR TITLE
Validate configuration before any network activity, and support secret files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,19 @@
-# Alarm.com credentials (alternative to config.yaml)
+# Alarm.com credentials. For Docker secrets, set ADC_USERNAME_FILE,
+# ADC_PASSWORD_FILE, and optionally ADC_MFA_TOKEN_FILE instead.
 ADC_USERNAME=
 ADC_PASSWORD=
 ADC_MFA_TOKEN=
+
+# Protect go2rtc's LAN-facing snapshot API and RTSP stream. Generate unique
+# random values; do not reuse the Alarm.com password.
+GO2RTC_API_USERNAME=adcbridge
+GO2RTC_API_PASSWORD=
+GO2RTC_RTSP_USERNAME=adcbridge
+GO2RTC_RTSP_PASSWORD=
+
+# Loopback is safest. Set this to the server LAN address only when Homebridge
+# is not in the same Docker network/host namespace.
+ADC_BRIDGE_BIND_ADDRESS=127.0.0.1
 
 # Logging
 LOG_LEVEL=info

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -1,7 +1,5 @@
-alarm:
-  username: "user@email.com"
-  password: "password"
-  mfaToken: ""  # optional, for 2FA bypass
+# Alarm.com credentials belong in .env (or ADC_*_FILE Docker secrets), not in
+# this mounted configuration file. Copy .env.example to .env and protect it.
 
 # Run "npx tsx src/discover.ts" to find your camera IDs and names
 cameras:

--- a/config/go2rtc.example.yaml
+++ b/config/go2rtc.example.yaml
@@ -1,8 +1,22 @@
 rtsp:
   listen: ":8554"
+  username: "${GO2RTC_RTSP_USERNAME}"
+  password: "${GO2RTC_RTSP_PASSWORD}"
 
 api:
   listen: ":1984"
+  username: "${GO2RTC_API_USERNAME}"
+  password: "${GO2RTC_API_PASSWORD}"
+  # Local bridge health/API calls bypass auth; remote clients must authenticate.
+  local_auth: false
+
+# These listeners are not used by the bridge. Disabling them reduces the
+# container's network surface.
+webrtc:
+  listen: ""
+
+srtp:
+  listen: ""
 
 # Each camera needs a matching stream entry.
 # Run "npx tsx src/discover.ts" to find your camera names.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -21,6 +21,9 @@ describe('loadConfig', () => {
     delete process.env.ADC_USERNAME;
     delete process.env.ADC_PASSWORD;
     delete process.env.ADC_MFA_TOKEN;
+    delete process.env.ADC_USERNAME_FILE;
+    delete process.env.ADC_PASSWORD_FILE;
+    delete process.env.ADC_MFA_TOKEN_FILE;
   });
 
   afterEach(() => {
@@ -50,6 +53,33 @@ alarm:
     const config = loadConfig();
     expect(config.alarm.username).toBe('file@test.com');
     expect(config.alarm.password).toBe('filepass');
+  });
+
+  it('prefers environment credentials over YAML credentials', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(`
+alarm:
+  username: "file@test.com"
+  password: "filepass"
+`);
+    process.env.ADC_USERNAME = 'env@test.com';
+    process.env.ADC_PASSWORD = 'envpass';
+
+    const config = loadConfig();
+    expect(config.alarm.username).toBe('env@test.com');
+    expect(config.alarm.password).toBe('envpass');
+  });
+
+  it('loads credentials from Docker secret files', () => {
+    process.env.ADC_USERNAME_FILE = '/run/secrets/adc_username';
+    process.env.ADC_PASSWORD_FILE = '/run/secrets/adc_password';
+    mockReadFileSync.mockImplementation((path) =>
+      String(path).endsWith('adc_username') ? 'secret@test.com\n' : 'secret-password\n',
+    );
+
+    const config = loadConfig();
+    expect(config.alarm.username).toBe('secret@test.com');
+    expect(config.alarm.password).toBe('secret-password');
   });
 
   it('applies go2rtc defaults when not in config', () => {
@@ -126,5 +156,48 @@ homebridge:
     process.env.ADC_PASSWORD = 'p';
     const config = loadConfig();
     expect(config.alarm.username).toBe('u');
+  });
+
+  it('rejects unsafe camera stream names', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(`
+cameras:
+  - id: "123-456"
+    name: "../front"
+    quality: "hd"
+`);
+    process.env.ADC_USERNAME = 'u';
+    process.env.ADC_PASSWORD = 'p';
+
+    expect(() => loadConfig()).toThrow('Camera name');
+  });
+
+  it('rejects duplicate camera IDs', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(`
+cameras:
+  - id: "123-456"
+    name: "front"
+    quality: "hd"
+  - id: "123-456"
+    name: "rear"
+    quality: "hd"
+`);
+    process.env.ADC_USERNAME = 'u';
+    process.env.ADC_PASSWORD = 'p';
+
+    expect(() => loadConfig()).toThrow('Duplicate camera ID');
+  });
+
+  it('rejects non-HTTP Homebridge webhook URLs', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(`
+homebridge:
+  motionUrl: "file:///tmp/hook"
+`);
+    process.env.ADC_USERNAME = 'u';
+    process.env.ADC_PASSWORD = 'p';
+
+    expect(() => loadConfig()).toThrow('homebridge.motionUrl must use HTTP or HTTPS');
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,10 @@ import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parse } from 'yaml';
 
+const CAMERA_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+const CAMERA_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{2,127}$/;
+const LOG_LEVELS = new Set(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent']);
+
 export interface CameraConfig {
   id: string;
   name: string;
@@ -42,6 +46,83 @@ const DEFAULT_CONFIG: Omit<AppConfig, 'alarm'> = {
   },
 };
 
+function readEnvironmentSecret(name: string): string | undefined {
+  const direct = process.env[name]?.trim();
+  if (direct) return direct;
+
+  const filePath = process.env[`${name}_FILE`]?.trim();
+  if (!filePath) return undefined;
+
+  try {
+    const value = readFileSync(filePath, 'utf-8').trim();
+    if (!value) throw new Error('file is empty');
+    return value;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Unable to read ${name}_FILE: ${message}`);
+  }
+}
+
+function validateHttpUrl(value: string, label: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${label} must be a valid HTTP or HTTPS URL.`);
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`${label} must use HTTP or HTTPS.`);
+  }
+
+  url.pathname = url.pathname.replace(/\/$/, '');
+  return url.toString().replace(/\/$/, '');
+}
+
+function validateConfig(config: AppConfig): AppConfig {
+  if (!Number.isInteger(config.go2rtc.rtspPort) || config.go2rtc.rtspPort < 1 || config.go2rtc.rtspPort > 65_535) {
+    throw new Error('go2rtc.rtspPort must be an integer between 1 and 65535.');
+  }
+
+  config.go2rtc.apiUrl = validateHttpUrl(config.go2rtc.apiUrl, 'go2rtc.apiUrl');
+
+  if (!LOG_LEVELS.has(config.logging.level)) {
+    throw new Error(`logging.level must be one of: ${[...LOG_LEVELS].join(', ')}.`);
+  }
+
+  const ids = new Set<string>();
+  const names = new Set<string>();
+  for (const camera of config.cameras) {
+    if (!CAMERA_ID_PATTERN.test(camera.id)) {
+      throw new Error(`Camera ID ${JSON.stringify(camera.id)} contains unsupported characters.`);
+    }
+    if (!CAMERA_NAME_PATTERN.test(camera.name)) {
+      throw new Error(
+        `Camera name ${JSON.stringify(camera.name)} must start with a lowercase letter or digit and contain only lowercase letters, digits, underscores, or hyphens.`,
+      );
+    }
+    if (camera.quality !== 'hd' && camera.quality !== 'sd') {
+      throw new Error(`Camera ${camera.name} quality must be "hd" or "sd".`);
+    }
+    if (ids.has(camera.id)) throw new Error(`Duplicate camera ID: ${camera.id}.`);
+    if (names.has(camera.name)) throw new Error(`Duplicate camera name: ${camera.name}.`);
+    ids.add(camera.id);
+    names.add(camera.name);
+  }
+
+  if (config.homebridge) {
+    config.homebridge.motionUrl = validateHttpUrl(
+      config.homebridge.motionUrl,
+      'homebridge.motionUrl',
+    );
+    if (!Number.isInteger(config.homebridge.motionTimeoutMs) || config.homebridge.motionTimeoutMs < 1_000) {
+      throw new Error('homebridge.motionTimeoutMs must be an integer of at least 1000 milliseconds.');
+    }
+  }
+
+  return config;
+}
+
 /**
  * Load config from YAML file, falling back to environment variables.
  * Config file is searched at: ./config/config.yaml, then ./config.yaml
@@ -63,9 +144,12 @@ export function loadConfig(): AppConfig {
   }
 
   const alarm = {
-    username: fileConfig.alarm?.username || process.env.ADC_USERNAME || '',
-    password: fileConfig.alarm?.password || process.env.ADC_PASSWORD || '',
-    mfaToken: fileConfig.alarm?.mfaToken || process.env.ADC_MFA_TOKEN || undefined,
+    // Environment or Docker secret files take precedence so production
+    // credentials never need to live in the mounted YAML configuration.
+    username: readEnvironmentSecret('ADC_USERNAME') || fileConfig.alarm?.username || '',
+    password: readEnvironmentSecret('ADC_PASSWORD') || fileConfig.alarm?.password || '',
+    mfaToken:
+      readEnvironmentSecret('ADC_MFA_TOKEN') || fileConfig.alarm?.mfaToken || undefined,
   };
 
   if (!alarm.username || !alarm.password) {
@@ -74,7 +158,7 @@ export function loadConfig(): AppConfig {
     );
   }
 
-  return {
+  return validateConfig({
     alarm,
     cameras: Array.isArray(fileConfig.cameras) ? fileConfig.cameras : DEFAULT_CONFIG.cameras,
     go2rtc: { ...DEFAULT_CONFIG.go2rtc, ...fileConfig.go2rtc },
@@ -85,5 +169,5 @@ export function loadConfig(): AppConfig {
         }
       : undefined,
     logging: { ...DEFAULT_CONFIG.logging, ...fileConfig.logging },
-  };
+  });
 }


### PR DESCRIPTION
Verified against this repo's own lockfile: builds clean, **113 tests pass** (73 lines of new tests included).

## Validate at load time, not at first use

Configuration was parsed but barely checked, so a typo surfaced much later and somewhere unrelated:

| mistake | how it currently presents |
|---|---|
| bad camera id | an Alarm.com API error, minutes in |
| bad stream name | a go2rtc 404 |
| bad port | connection refused |
| duplicate camera id | one camera silently shadowing another |

Now checked at load: camera ids and stream names against safe character sets, ports and timeouts as numbers in range, URLs as parseable, and duplicates rejected outright. Failure names the offending field and happens **before anything opens a socket**.

The duplicate check matters more than it looks — two entries sharing a stream name produce two publishers pushing to one go2rtc path, which is confusing to diagnose from the far end.

## Secret files

Adds `ADC_USERNAME_FILE`, `ADC_PASSWORD_FILE`, `ADC_MFA_TOKEN_FILE`, so credentials can come from Docker secrets or any mode-600 file instead of the environment. Environment variables still take precedence where both are set; the file form is entirely opt-in and changes nothing for existing setups.

## Tests

73 lines covering the validation paths, including the duplicate-detection cases — those are the easiest to regress silently, since the failure mode is a working-looking config.

---

Part of a series splitting a large hardening change into reviewable pieces. Independent of #28 and #29 — no overlapping files.