### PR TITLE
Stop the retry loops from running forever with a circuit breaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The bridge refreshes video tokens every 10 minutes, tearing down and re-establis
 - Docker container with go2rtc sidecar
 - Multi-camera streaming (3 cameras verified, 1920x1080 H.264 @ 10fps)
 - Camera dial-in retry with exponential backoff (up to 12 attempts)
+- Circuit breakers on all three Alarm.com retry loops (see [Retry limits](#retry-limits))
 - Real-time motion detection via ADC WebSocket event stream
 - WebSocket event listener with proactive token refresh and exponential backoff on errors
 - Motion webhook forwarding to homebridge-camera-ffmpeg
@@ -120,6 +121,7 @@ src/
 ├── go2rtc/
 │   └── go2rtc-api.ts         # go2rtc REST API health checks
 └── utils/
+    ├── circuit-breaker.ts    # Pauses a retry loop that is getting nowhere
     ├── logger.ts             # pino structured logging
     ├── retry.ts              # Exponential backoff helper
     └── sdp.ts                # H.264 fmtp extraction from SDP offers
@@ -175,6 +177,25 @@ Alarm.com may ban accounts that poll too aggressively. Known safe minimums (from
 - **Device polling**: ≥60 seconds (bridge uses 10 min per camera)
 
 With multiple cameras, aggregate API load scales linearly — 3 cameras means a video token API call roughly every 200 seconds.
+
+### Retry limits
+
+Exponential backoff bounds the *rate* between attempts but not the *duration* of
+attempting: a saturated ladder is still an infinite loop. Each of the three
+Alarm.com retry loops — the video token poll, the stream retry ladder, and the
+event WebSocket — is therefore wrapped in a circuit breaker. After a run of
+consecutive failures the loop pauses, logs once at `error`, and continues only as
+occasional probes on an escalating cooldown (5 min → 15 min → 30 min → 1 hour,
+then hourly). It probes indefinitely and closes on the first success, so recovery
+needs no restart.
+
+An open circuit appears in the periodic status line as `(circuit open)` next to
+the affected camera, or as `eventCircuit: open` for the event stream.
+
+The breaker treats "did not produce a usable result" as the failure, not "threw".
+Alarm.com answers a camera it cannot reach with HTTP 200 and `errorEnum: 0`, and
+simply omits the WebRTC block — so a breaker counting exceptions would sit closed
+through exactly the outage it exists for.
 
 ## Future exploration
 

--- a/src/auth/token-manager.test.ts
+++ b/src/auth/token-manager.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../utils/logger.js', () => ({
+  createChildLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { TokenManager, VIDEO_TOKEN_FAILURE_THRESHOLD } from './token-manager.js';
+import type { AlarmAuth } from './alarm-auth.js';
+
+const FIVE_MIN = 5 * 60_000;
+/** `retry` uses 1s then 2s between its three attempts. */
+const RETRY_LADDER_MS = 3_000;
+
+/**
+ * What Alarm.com returns for a camera it cannot reach: HTTP 200,
+ * `errorEnum: 0`, and no end-to-end WebRTC block. A success by every measure
+ * except the only one that counts.
+ */
+function noWebrtcResponse() {
+  return {
+    // `iceServers` arrives as a JSON *string*, not an array — the shape the
+    // parser actually has to cope with.
+    data: { attributes: { iceServers: '[]' } },
+    included: [
+      { type: 'video/videoSources/proxyWebrtcConnectionInfo', attributes: { proxyStreamTimeoutTime: 180 } },
+    ],
+  };
+}
+
+function usableResponse() {
+  return {
+    data: { attributes: { iceServers: '[]' } },
+    included: [
+      {
+        type: 'video/videoSources/endToEndWebrtcConnectionInfo',
+        attributes: {
+          signallingServerUrl: 'wss://signal.example.com',
+          signallingServerToken: 'signal-token',
+          cameraAuthToken: 'camera-auth-token',
+        },
+      },
+    ],
+  };
+}
+
+function createAuthStub() {
+  return {
+    get: vi.fn().mockResolvedValue(usableResponse()),
+    isSessionFresh: vi.fn().mockReturnValue(true),
+    authenticate: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('TokenManager circuit breaker', () => {
+  let manager: TokenManager;
+  let auth: ReturnType<typeof createAuthStub>;
+  let emittedErrors: Error[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    auth = createAuthStub();
+    manager = new TokenManager(auth as unknown as AlarmAuth);
+    emittedErrors = [];
+    // EventEmitter throws on an 'error' event with no listener.
+    manager.on('error', (_cameraId, error) => emittedErrors.push(error));
+  });
+
+  afterEach(() => {
+    manager.stop();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  /** Exhaust the breaker with responses that carry no WebRTC configuration. */
+  async function failUntilOpen(cameraId = 'cam-1') {
+    auth.get.mockResolvedValue(noWebrtcResponse());
+    for (let i = 0; i < VIDEO_TOKEN_FAILURE_THRESHOLD; i++) {
+      await manager.fetchVideoTokenSilent(cameraId);
+    }
+  }
+
+  it('trips on responses that produce nothing usable without ever throwing', async () => {
+    await failUntilOpen();
+
+    // The whole point. Nothing threw, no 'error' event was emitted, and every
+    // call looked like a success returning nothing — which is exactly what a
+    // seven-hour outage looked like from inside this code. A breaker keyed on
+    // exceptions would still be closed here.
+    expect(emittedErrors).toHaveLength(0);
+    expect(manager.circuitState('cam-1')).toBe('open');
+  });
+
+  it('stops calling Alarm.com once open', async () => {
+    await failUntilOpen();
+    auth.get.mockClear();
+
+    await expect(manager.fetchVideoTokenSilent('cam-1')).resolves.toBeNull();
+
+    expect(auth.get).not.toHaveBeenCalled();
+  });
+
+  it('probes after the cooldown and closes on the first usable response', async () => {
+    await failUntilOpen();
+
+    await vi.advanceTimersByTimeAsync(FIVE_MIN);
+    auth.get.mockResolvedValue(usableResponse());
+
+    await expect(manager.fetchVideoTokenSilent('cam-1')).resolves.toMatchObject({
+      cameraAuthToken: 'camera-auth-token',
+    });
+    expect(manager.circuitState('cam-1')).toBe('closed');
+  });
+
+  it('does not emit videoToken while suppressed, and emits again once closed', async () => {
+    const tokens: string[] = [];
+    manager.on('videoToken', (cameraId) => tokens.push(cameraId));
+
+    await failUntilOpen();
+    await manager.fetchVideoToken('cam-1');
+    expect(tokens).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(FIVE_MIN);
+    auth.get.mockResolvedValue(usableResponse());
+    await manager.fetchVideoToken('cam-1');
+
+    expect(tokens).toEqual(['cam-1']);
+  });
+
+  it('counts thrown errors as well as empty results', async () => {
+    auth.get.mockRejectedValue(new Error('ECONNRESET'));
+
+    for (let i = 0; i < VIDEO_TOKEN_FAILURE_THRESHOLD; i++) {
+      const pending = manager.fetchVideoTokenSilent('cam-1');
+      await vi.advanceTimersByTimeAsync(RETRY_LADDER_MS);
+      await pending;
+    }
+
+    expect(emittedErrors).toHaveLength(VIDEO_TOKEN_FAILURE_THRESHOLD);
+    expect(manager.circuitState('cam-1')).toBe('open');
+  });
+
+  it('keeps circuits per camera, so one sick camera does not pause the others', async () => {
+    await failUntilOpen('cam-1');
+
+    expect(manager.circuitState('cam-1')).toBe('open');
+    expect(manager.circuitState('cam-2')).toBe('closed');
+
+    auth.get.mockResolvedValue(usableResponse());
+    await expect(manager.fetchVideoTokenSilent('cam-2')).resolves.not.toBeNull();
+  });
+
+  it('reports a closed circuit for a camera that has never been fetched', () => {
+    expect(manager.circuitState('unknown')).toBe('closed');
+  });
+});

--- a/src/auth/token-manager.ts
+++ b/src/auth/token-manager.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events';
 import { createChildLogger } from '../utils/logger.js';
 import { retry, sleep } from '../utils/retry.js';
+import { CircuitBreaker, type CircuitState } from '../utils/circuit-breaker.js';
 import { AlarmAuth } from './alarm-auth.js';
 import type { EndToEndWebrtcConfig } from '../types.js';
 
@@ -8,6 +9,13 @@ const log = createChildLogger('token-manager');
 
 const SESSION_REFRESH_MS = 55 * 60 * 1000;
 const VIDEO_TOKEN_REFRESH_MS = 600 * 1000;
+/**
+ * Three consecutive fetches that produce nothing usable. A fetch that *throws*
+ * is retried 3× inside `retry()`, so the worst case is 9 API calls; a fetch
+ * that merely returns an empty result costs one call, because `retry()` only
+ * re-attempts on a thrown error.
+ */
+export const VIDEO_TOKEN_FAILURE_THRESHOLD = 3;
 const VIDEO_SOURCE_URL =
   'https://www.alarm.com/web/api/video/videoSources/liveVideoHighestResSources/';
 
@@ -26,6 +34,7 @@ interface TokenManagerEvents {
 export class TokenManager extends EventEmitter {
   private sessionTimer: ReturnType<typeof setInterval> | null = null;
   private cameraTimers = new Map<string, ReturnType<typeof setInterval>>();
+  private breakers = new Map<string, CircuitBreaker>();
   private running = false;
 
   constructor(private readonly auth: AlarmAuth) {
@@ -76,24 +85,55 @@ export class TokenManager extends EventEmitter {
   /**
    * Fetch a fresh video token WITHOUT emitting events.
    * Used by camera-stream during dial-in retries to avoid restarting the stream.
+   *
+   * Guarded by a per-camera circuit breaker. While the circuit is open this
+   * returns `null` without touching the network; the 600s timer keeps ticking
+   * but only the tick after a cooldown expires reaches Alarm.com, so the
+   * effective probe interval is the longer of the two.
+   *
+   * Note that camera-stream's dial-in loop shares this breaker — it can call
+   * here up to 12 times per start attempt. That is intended: those refetches
+   * are the same API call and count the same. A suppressed refetch simply
+   * returns `null` and the dial-in loop reuses its existing config.
    */
   async fetchVideoTokenSilent(cameraId: string): Promise<EndToEndWebrtcConfig | null> {
+    const breaker = this.breakerFor(cameraId);
+    if (!breaker.tryAttempt()) {
+      log.debug({ cameraId }, 'Video token fetch suppressed — circuit open');
+      return null;
+    }
+
     try {
       const config = await retry(
         () => this.fetchVideoSource(cameraId),
         { maxAttempts: 3, label: `videoToken:${cameraId}` },
       );
 
-      if (config) return config;
+      if (config) {
+        breaker.recordSuccess();
+        return config;
+      }
 
+      // 🔑 This branch is the one that matters. A response with no end-to-end
+      // WebRTC block is HTTP 200 with `errorEnum: 0` — a success by every
+      // measure except the only one that counts. It does not throw and does
+      // not emit `error`, so a breaker keyed on exceptions would sit closed
+      // through the entire outage. Record it as the failure it is.
+      breaker.recordFailure('response carried no end-to-end WebRTC configuration');
       log.warn({ cameraId }, 'No WebRTC config in response');
       return null;
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
+      breaker.recordFailure(error.message);
       log.error({ cameraId }, 'Video token fetch failed: %s', error.message);
       this.emit('error', cameraId, error);
       return null;
     }
+  }
+
+  /** Circuit state for a camera's token loop, for status reporting. */
+  circuitState(cameraId: string): CircuitState {
+    return this.breakers.get(cameraId)?.state ?? 'closed';
   }
 
   /** Stop all timers and clean up. */
@@ -110,6 +150,18 @@ export class TokenManager extends EventEmitter {
       log.debug({ cameraId }, 'Stopped camera timer');
     }
     this.cameraTimers.clear();
+  }
+
+  private breakerFor(cameraId: string): CircuitBreaker {
+    let breaker = this.breakers.get(cameraId);
+    if (!breaker) {
+      breaker = new CircuitBreaker({
+        label: `videoToken:${cameraId}`,
+        failureThreshold: VIDEO_TOKEN_FAILURE_THRESHOLD,
+      });
+      this.breakers.set(cameraId, breaker);
+    }
+    return breaker;
   }
 
   private startCameraTimer(cameraId: string): void {

--- a/src/camera/camera-manager.test.ts
+++ b/src/camera/camera-manager.test.ts
@@ -45,6 +45,7 @@ function createTokenManagerStub() {
     stop: vi.fn(),
     fetchVideoToken: vi.fn().mockResolvedValue(null),
     fetchVideoTokenSilent: vi.fn().mockResolvedValue(null),
+    circuitState: vi.fn().mockReturnValue('closed' as const),
   });
   return stub as unknown as TokenManager & typeof stub;
 }
@@ -123,20 +124,20 @@ describe('CameraManager backoff', () => {
     expect(tokenManager.fetchVideoToken).toHaveBeenCalledTimes(1);
   });
 
-  it('caps delay at 10 minutes after many failures', async () => {
+  it('caps the ladder delay at 10 minutes on its last rung', async () => {
     await startWithCamera();
     const stream = getStream();
     stream.start.mockRejectedValue(new Error('camera offline'));
 
-    // Run through 5+ failures to exceed the backoff steps array
-    for (let i = 0; i < 6; i++) {
+    // Failures 1-4 walk the ladder: 30s, 60s, 120s, 300s.
+    for (const delay of [30_000, 60_000, 120_000, 300_000]) {
       tokenManager.emit('videoToken', 'cam-1', makeConfig());
       await vi.advanceTimersByTimeAsync(0);
-      tokenManager.fetchVideoToken.mockClear();
-      await vi.advanceTimersByTimeAsync(600_000); // 10 min max
+      await vi.advanceTimersByTimeAsync(delay);
     }
 
-    // 7th failure should still be capped at 10 minutes
+    // Failure 5 lands on the clamp. The circuit opens on failure 6, so this is
+    // the only rung where the 10-minute cap is the delay actually used.
     tokenManager.emit('videoToken', 'cam-1', makeConfig());
     await vi.advanceTimersByTimeAsync(0);
     tokenManager.fetchVideoToken.mockClear();
@@ -264,6 +265,111 @@ describe('CameraManager backoff', () => {
 
     expect(stream.reconnect).not.toHaveBeenCalled();
     expect(stream.start).toHaveBeenCalledOnce();
+  });
+
+  describe('circuit breaker', () => {
+    const LADDER_MS = [30_000, 60_000, 120_000, 300_000, 600_000];
+    const FIVE_MIN = 5 * 60_000;
+
+    /** Make the stub behave like the real fetch: a usable token is emitted. */
+    function autoEmitTokens() {
+      tokenManager.fetchVideoToken.mockImplementation(async (id: string) => {
+        const config = makeConfig();
+        tokenManager.emit('videoToken', id, config);
+        return config;
+      });
+    }
+
+    /**
+     * Walk the ladder to its end, which is six failures and opens the circuit,
+     * then consume `probes` further probes on the escalating cooldown.
+     */
+    async function driveUntilOpen(probes = 0) {
+      const cooldowns = [FIVE_MIN, 15 * 60_000, 30 * 60_000];
+      tokenManager.emit('videoToken', 'cam-1', makeConfig());
+      await vi.advanceTimersByTimeAsync(0);
+      for (const delay of LADDER_MS) await vi.advanceTimersByTimeAsync(delay);
+      for (let i = 0; i < probes; i++) await vi.advanceTimersByTimeAsync(cooldowns[i]);
+    }
+
+    it('opens once the ladder is exhausted and says so in the status line', async () => {
+      autoEmitTokens();
+      await startWithCamera();
+      getStream().start.mockRejectedValue(new Error('camera offline'));
+
+      await driveUntilOpen();
+
+      expect(manager.getStatus()).toEqual({ driveway: 'idle (circuit open)' });
+    });
+
+    it('collapses the retry rate: 6 attempts/hour on the ladder, 3 once open', async () => {
+      autoEmitTokens();
+      await startWithCamera();
+      const stream = getStream();
+      stream.start.mockRejectedValue(new Error('camera offline'));
+
+      await driveUntilOpen();
+      stream.start.mockClear();
+
+      await vi.advanceTimersByTimeAsync(60 * 60_000);
+
+      // Probes at +5m, +20m, +50m. The saturated ladder would have retried
+      // every 10 minutes, forever, and never stopped.
+      expect(stream.start).toHaveBeenCalledTimes(3);
+    });
+
+    it('bounds the mid-stream recovery path, which has no backoff of its own', async () => {
+      autoEmitTokens();
+      await startWithCamera();
+      const stream = getStream();
+      stream.start.mockRejectedValue(new Error('camera offline'));
+
+      await driveUntilOpen(1);
+      stream.start.mockClear();
+
+      // handleUnexpectedExit refetches immediately — no ladder, no delay. With
+      // the next probe 15 minutes out, the circuit is the only thing stopping
+      // a dying ffmpeg from hammering Alarm.com.
+      stream.onUnexpectedExit();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(stream.start).not.toHaveBeenCalled();
+    });
+
+    it('closes itself on the first successful probe, with no restart needed', async () => {
+      autoEmitTokens();
+      await startWithCamera();
+      const stream = getStream();
+      stream.start.mockRejectedValue(new Error('camera offline'));
+
+      await driveUntilOpen();
+
+      // A camera demoted by a weak link recovers on its own once the link
+      // improves, with nothing restarting the bridge, so the circuit has to
+      // notice recovery by itself.
+      stream.start.mockResolvedValue(undefined);
+      await vi.advanceTimersByTimeAsync(FIVE_MIN);
+
+      expect(manager.getStatus()).toEqual({ driveway: 'idle' });
+
+      // And the fast ladder is available again from its first rung.
+      stream.start.mockRejectedValue(new Error('camera offline'));
+      tokenManager.emit('videoToken', 'cam-1', makeConfig());
+      await vi.advanceTimersByTimeAsync(0);
+      stream.start.mockClear();
+
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(stream.start).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      expect(stream.start).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports an open token circuit even when the stream circuit is closed', async () => {
+      await startWithCamera();
+      tokenManager.circuitState.mockReturnValue('open');
+
+      expect(manager.getStatus()).toEqual({ driveway: 'idle (circuit open)' });
+    });
   });
 
   it('does not retry when manager is stopped', async () => {

--- a/src/camera/camera-manager.ts
+++ b/src/camera/camera-manager.ts
@@ -1,5 +1,6 @@
 import { createChildLogger } from '../utils/logger.js';
 import { TokenManager } from '../auth/token-manager.js';
+import { CircuitBreaker } from '../utils/circuit-breaker.js';
 import { CameraStream } from './camera-stream.js';
 import type { CameraConfig } from '../config.js';
 import type { EndToEndWebrtcConfig } from '../types.js';
@@ -7,6 +8,14 @@ import type { EndToEndWebrtcConfig } from '../types.js';
 const log = createChildLogger('camera-manager');
 
 const BACKOFF_STEPS_MS = [30_000, 60_000, 120_000, 300_000, 600_000];
+/**
+ * One failure per rung plus one: the ladder is walked to its 10-minute cap and
+ * applied once before the circuit opens, ~18 minutes into a camera that will
+ * not start. This is the least urgent of the three loops — its own cap already
+ * bounds it to ~6 attempts/hour, and a failure here often means one sick camera
+ * rather than an Alarm.com outage.
+ */
+export const STREAM_FAILURE_THRESHOLD = BACKOFF_STEPS_MS.length + 1;
 
 /**
  * Orchestrates multiple camera stream pipelines.
@@ -16,6 +25,7 @@ export class CameraManager {
   private streams = new Map<string, CameraStream>();
   private activeStarts = new Set<string>();
   private failureCount = new Map<string, number>();
+  private breakers = new Map<string, CircuitBreaker>();
   private running = false;
 
   constructor(
@@ -67,7 +77,11 @@ export class CameraManager {
   getStatus(): Record<string, string> {
     const status: Record<string, string> = {};
     for (const [id, stream] of this.streams) {
-      status[stream.cameraName] = stream.state;
+      // Surface a paused loop in the periodic status line, so an operator
+      // reading the logs sees why an idle camera is not being retried.
+      const paused =
+        this.breakers.get(id)?.state === 'open' || this.tokenManager.circuitState(id) === 'open';
+      status[stream.cameraName] = paused ? `${stream.state} (circuit open)` : stream.state;
     }
     return status;
   }
@@ -85,6 +99,8 @@ export class CameraManager {
       return;
     }
 
+    const breaker = this.breakerFor(cameraId);
+
     // If the stream is already active, do a seamless reconnect (keeps ffmpeg alive)
     if (stream.state === 'streaming') {
       this.activeStarts.add(cameraId);
@@ -92,6 +108,7 @@ export class CameraManager {
         log.info({ camera: stream.cameraName }, 'Seamless reconnect with fresh token');
         await stream.reconnect(config);
         this.failureCount.delete(cameraId);
+        breaker.recordSuccess();
         this.activeStarts.delete(cameraId);
         return;
       } catch (err) {
@@ -99,6 +116,14 @@ export class CameraManager {
         log.warn({ camera: stream.cameraName }, 'Reconnect failed (%s), falling back to full restart', msg);
         this.activeStarts.delete(cameraId);
       }
+    }
+
+    // A token can arrive from the 600s refresh timer as well as from the retry
+    // ladder below, so the ladder's delay alone does not bound how often a
+    // hopeless start is attempted. The circuit does.
+    if (!breaker.tryAttempt()) {
+      log.debug({ camera: stream.cameraName }, 'Stream start suppressed — circuit open');
+      return;
     }
 
     this.activeStarts.add(cameraId);
@@ -111,13 +136,18 @@ export class CameraManager {
       await stream.start(config, refetchToken);
 
       this.failureCount.delete(cameraId);
+      breaker.recordSuccess();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.error({ camera: stream.cameraName }, 'Stream failed after all retries: %s', msg);
+      breaker.recordFailure(msg);
 
       if (this.running) {
         const failures = this.failureCount.get(cameraId) ?? 0;
-        const delay = BACKOFF_STEPS_MS[Math.min(failures, BACKOFF_STEPS_MS.length - 1)];
+        const delay =
+          breaker.state === 'open'
+            ? breaker.retryAfterMs()
+            : BACKOFF_STEPS_MS[Math.min(failures, BACKOFF_STEPS_MS.length - 1)];
         this.failureCount.set(cameraId, failures + 1);
 
         log.info({ camera: stream.cameraName, delay: delay / 1000, failures: failures + 1 }, 'Will retry in %ds', delay / 1000);
@@ -131,6 +161,18 @@ export class CameraManager {
     }
 
     this.activeStarts.delete(cameraId);
+  }
+
+  private breakerFor(cameraId: string): CircuitBreaker {
+    let breaker = this.breakers.get(cameraId);
+    if (!breaker) {
+      breaker = new CircuitBreaker({
+        label: `stream:${cameraId}`,
+        failureThreshold: STREAM_FAILURE_THRESHOLD,
+      });
+      this.breakers.set(cameraId, breaker);
+    }
+    return breaker;
   }
 
   private handleUnexpectedExit(cameraId: string): void {

--- a/src/events/alarm-event-listener.test.ts
+++ b/src/events/alarm-event-listener.test.ts
@@ -48,6 +48,9 @@ import type { AlarmAuth } from '../auth/alarm-auth.js';
 type AuthStub = ReturnType<typeof createAuthStub>;
 
 const TOKEN_REFRESH_MS = 240_000;
+/** The listener's own backoff ladder — five rungs is EVENT_FAILURE_THRESHOLD. */
+const LADDER_MS = [5_000, 10_000, 30_000, 60_000];
+const FIVE_MIN = 5 * 60_000;
 
 function createAuthStub() {
   return {
@@ -141,19 +144,18 @@ describe('AlarmEventListener reconnection', () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(getInstances()).toHaveLength(4);
 
-    // Failure 4 → 60s (capped)
+    // Failure 4 → 60s (the ladder's cap)
     closeWs(getInstances()[3], 1006);
     await vi.advanceTimersByTimeAsync(59_999);
     expect(getInstances()).toHaveLength(4);
     await vi.advanceTimersByTimeAsync(1);
     expect(getInstances()).toHaveLength(5);
 
-    // Failure 5 → still 60s (capped)
+    // Failure 5 hits EVENT_FAILURE_THRESHOLD and opens the circuit, so the
+    // ladder's 60s cap no longer applies — see the circuit breaker suite below.
+    expect(listener.circuitState).toBe('closed');
     closeWs(getInstances()[4], 1006);
-    await vi.advanceTimersByTimeAsync(59_999);
-    expect(getInstances()).toHaveLength(5);
-    await vi.advanceTimersByTimeAsync(1);
-    expect(getInstances()).toHaveLength(6);
+    expect(listener.circuitState).toBe('open');
   });
 
   it('resets backoff counter after successful connection', async () => {
@@ -272,5 +274,101 @@ describe('AlarmEventListener reconnection', () => {
     // Advance past the refresh point
     await vi.advanceTimersByTimeAsync(1);
     expect(getInstances()).toHaveLength(1);
+  });
+
+  describe('circuit breaker', () => {
+    /** Drive the listener through five handshakes that never reach `open`. */
+    async function failUntilOpen() {
+      for (const delay of LADDER_MS) {
+        closeWs(getInstances()[getInstances().length - 1], 1006);
+        await vi.advanceTimersByTimeAsync(delay);
+      }
+      closeWs(getInstances()[getInstances().length - 1], 1006);
+    }
+
+    it('opens after five handshake failures and abandons the fast ladder', async () => {
+      await listener.start();
+      await failUntilOpen();
+
+      expect(listener.circuitState).toBe('open');
+      expect(getInstances()).toHaveLength(5);
+
+      // The ladder would have reconnected at 60s. The circuit does not.
+      await vi.advanceTimersByTimeAsync(FIVE_MIN - 1);
+      expect(getInstances()).toHaveLength(5);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(getInstances()).toHaveLength(6);
+    });
+
+    it('escalates the cooldown when a probe also fails', async () => {
+      await listener.start();
+      await failUntilOpen();
+
+      await vi.advanceTimersByTimeAsync(FIVE_MIN);
+      expect(getInstances()).toHaveLength(6);
+
+      // Probe failed → next probe is 15 minutes out, not another 5.
+      closeWs(getInstances()[5], 1006);
+      await vi.advanceTimersByTimeAsync(FIVE_MIN);
+      expect(getInstances()).toHaveLength(6);
+
+      await vi.advanceTimersByTimeAsync(10 * 60_000);
+      expect(getInstances()).toHaveLength(7);
+    });
+
+    it('closes on the first successful probe and restores the fast ladder', async () => {
+      await listener.start();
+      await failUntilOpen();
+
+      await vi.advanceTimersByTimeAsync(FIVE_MIN);
+      openLatestWs();
+
+      expect(listener.circuitState).toBe('closed');
+
+      // Back on the 5s first rung — a breaker that needed a restart to clear
+      // would have kept the listener dark instead.
+      closeWs(getInstances()[5], 1006);
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(getInstances()).toHaveLength(6);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(getInstances()).toHaveLength(7);
+    });
+
+    it('does not open while sockets keep opening, however often they drop', async () => {
+      await listener.start();
+
+      for (let i = 0; i < 10; i++) {
+        const ws = openLatestWs();
+        closeWs(ws, 1006);
+        await vi.advanceTimersByTimeAsync(5_000);
+      }
+
+      // Each socket reached `open`, so Alarm.com is answering. Flapping is a
+      // different fault from an outage and must not pause the loop.
+      expect(listener.circuitState).toBe('closed');
+      expect(getInstances()).toHaveLength(11);
+    });
+
+    it('counts token failures that never reach a socket, and cuts the call rate', async () => {
+      listener.on('error', () => {}); // prevent unhandled error event
+      auth.get.mockRejectedValue(new Error('network error'));
+
+      await listener.start();
+      for (const delay of LADDER_MS) {
+        await vi.advanceTimersByTimeAsync(delay);
+      }
+
+      // Five attempts inside ~105 seconds — the measured ~60/hour rate.
+      expect(listener.circuitState).toBe('open');
+      expect(auth.get).toHaveBeenCalledTimes(5);
+      expect(getInstances()).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(FIVE_MIN - 1);
+      expect(auth.get).toHaveBeenCalledTimes(5);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(auth.get).toHaveBeenCalledTimes(6);
+    });
   });
 });

--- a/src/events/alarm-event-listener.ts
+++ b/src/events/alarm-event-listener.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events';
 import WebSocket from 'ws';
 import { createChildLogger } from '../utils/logger.js';
 import { retry } from '../utils/retry.js';
+import { CircuitBreaker, type CircuitState } from '../utils/circuit-breaker.js';
 import type { AlarmAuth } from '../auth/alarm-auth.js';
 import {
   EventType,
@@ -16,6 +17,13 @@ const WS_TOKEN_URL = 'https://www.alarm.com/web/api/websockets/token';
 const TOKEN_REFRESH_MS = 240_000;
 const BACKOFF_STEPS_MS = [5_000, 10_000, 30_000, 60_000];
 const EXPECTED_CLOSE_CODES: ReadonlySet<number> = new Set([1000, 1008]);
+/**
+ * Five consecutive failures is roughly 2.5 minutes of the backoff ladder above.
+ * This is the loop that matters most: measured at ~60 failures/hour during a
+ * sustained multi-hour outage, ten times the token poller's rate, because its
+ * ladder caps at 60s and nothing ever stopped it.
+ */
+export const EVENT_FAILURE_THRESHOLD = 5;
 
 interface WsTokenResponse {
   value: string;
@@ -34,9 +42,18 @@ export class AlarmEventListener extends EventEmitter {
   private refreshTimer: ReturnType<typeof setTimeout> | null = null;
   private consecutiveFailures = 0;
   private running = false;
+  private readonly breaker = new CircuitBreaker({
+    label: 'events',
+    failureThreshold: EVENT_FAILURE_THRESHOLD,
+  });
 
   constructor(private readonly auth: AlarmAuth) {
     super();
+  }
+
+  /** Circuit state for this listener, for status reporting. */
+  get circuitState(): CircuitState {
+    return this.breaker.state;
   }
 
   async start(): Promise<void> {
@@ -70,6 +87,23 @@ export class AlarmEventListener extends EventEmitter {
 
   private async connect(): Promise<void> {
     this.clearTimers();
+
+    if (!this.breaker.tryAttempt()) {
+      log.debug('Reconnect suppressed — circuit open');
+      // A denied attempt always leaves a positive remainder, but scheduling 0
+      // here would recurse into connect() synchronously and blow the stack, so
+      // do not let that invariant be the only thing standing between a future
+      // refactor and a crash loop.
+      this.scheduleReconnect(Math.max(1, this.breaker.retryAfterMs()));
+      return;
+    }
+
+    // Whether this particular socket ever reached `open`. A socket that never
+    // opened produced no usable result and is a circuit failure; one that
+    // opened and later closed already recorded its success, and its close is
+    // the start of a new attempt rather than the failure of this one.
+    let opened = false;
+
     try {
       const tokenResponse = await retry(
         () => this.auth.get<WsTokenResponse>(WS_TOKEN_URL),
@@ -88,7 +122,9 @@ export class AlarmEventListener extends EventEmitter {
 
       this.ws.on('open', () => {
         log.info('WebSocket connected to %s', endpoint);
+        opened = true;
         this.consecutiveFailures = 0;
+        this.breaker.recordSuccess();
         this.refreshTimer = setTimeout(() => {
           this.refreshTimer = null;
           log.info('Proactive token refresh');
@@ -110,6 +146,14 @@ export class AlarmEventListener extends EventEmitter {
         this.ws = null;
         this.clearTimers();
 
+        if (!opened) {
+          // Never opened — the handshake was rejected. This is the shape the
+          // observed ~60/hour 401s took, and none of them threw.
+          this.breaker.recordFailure(`closed before open (code ${code})`);
+          this.scheduleReconnect(this.nextBackoffDelay());
+          return;
+        }
+
         if (EXPECTED_CLOSE_CODES.has(code)) {
           this.scheduleReconnect(0);
         } else {
@@ -119,6 +163,7 @@ export class AlarmEventListener extends EventEmitter {
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       log.error('Failed to connect: %s', error.message);
+      this.breaker.recordFailure(error.message);
       this.emit('error', error);
       this.scheduleReconnect(this.nextBackoffDelay());
     }
@@ -154,6 +199,11 @@ export class AlarmEventListener extends EventEmitter {
   }
 
   private nextBackoffDelay(): number {
+    // Once the circuit is open the fast ladder is abandoned for the breaker's
+    // escalating cooldown; the ladder's own cap of 60s is what made this loop
+    // the dominant source of failed calls during a sustained outage.
+    if (this.breaker.state === 'open') return this.breaker.retryAfterMs();
+
     const delay = BACKOFF_STEPS_MS[Math.min(this.consecutiveFailures, BACKOFF_STEPS_MS.length - 1)];
     this.consecutiveFailures++;
     return delay;

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,8 +123,14 @@ async function main(): Promise<void> {
 
   // Periodic status logging
   statusTimer = setInterval(() => {
-    const status = cameraManager.getStatus();
-    log.info({ streams: status }, 'Stream status');
+    const streams = cameraManager.getStatus();
+    // The event circuit is only worth a field when it is open; a healthy one
+    // would be noise on every line.
+    if (eventListener.circuitState === 'open') {
+      log.info({ streams, eventCircuit: 'open' }, 'Stream status');
+    } else {
+      log.info({ streams }, 'Stream status');
+    }
   }, 60_000);
 }
 

--- a/src/utils/circuit-breaker.test.ts
+++ b/src/utils/circuit-breaker.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { logSpy } = vi.hoisted(() => ({
+  logSpy: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('./logger.js', () => ({
+  createChildLogger: () => logSpy,
+}));
+
+import { CircuitBreaker, DEFAULT_COOLDOWN_STEPS_MS } from './circuit-breaker.js';
+
+const MIN = 60_000;
+
+/** Controllable clock so the state machine can be tested without timers. */
+function createClock() {
+  let t = 1_000_000;
+  return {
+    now: () => t,
+    advance: (ms: number) => { t += ms; },
+  };
+}
+
+function createBreaker(overrides: Partial<{ failureThreshold: number; cooldownStepsMs: number[] }> = {}) {
+  const clock = createClock();
+  const breaker = new CircuitBreaker({
+    label: 'test',
+    failureThreshold: 3,
+    now: clock.now,
+    ...overrides,
+  });
+  return { breaker, clock };
+}
+
+describe('CircuitBreaker', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('stays closed and permits attempts below the failure threshold', () => {
+    const { breaker } = createBreaker();
+
+    breaker.recordFailure('nope');
+    breaker.recordFailure('nope');
+
+    expect(breaker.state).toBe('closed');
+    expect(breaker.consecutiveFailures).toBe(2);
+    expect(breaker.tryAttempt()).toBe(true);
+    expect(breaker.retryAfterMs()).toBe(0);
+  });
+
+  it('opens on the threshold-th consecutive failure', () => {
+    const { breaker } = createBreaker();
+
+    breaker.recordFailure('a');
+    breaker.recordFailure('b');
+    expect(breaker.state).toBe('closed');
+
+    breaker.recordFailure('c');
+    expect(breaker.state).toBe('open');
+    expect(breaker.retryAfterMs()).toBe(5 * MIN);
+  });
+
+  it('logs the opening once, loudly, and not again while it stays open', () => {
+    const { breaker, clock } = createBreaker();
+
+    for (let i = 0; i < 3; i++) breaker.recordFailure('down');
+    expect(logSpy.error).toHaveBeenCalledTimes(1);
+
+    // Suppressed attempts and failed probes must not re-raise the alarm.
+    breaker.tryAttempt();
+    clock.advance(5 * MIN);
+    breaker.tryAttempt();
+    breaker.recordFailure('still down');
+
+    expect(logSpy.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('denies attempts while open until the cooldown has elapsed', () => {
+    const { breaker, clock } = createBreaker();
+    for (let i = 0; i < 3; i++) breaker.recordFailure('down');
+
+    clock.advance(5 * MIN - 1);
+    expect(breaker.tryAttempt()).toBe(false);
+    expect(breaker.retryAfterMs()).toBe(1);
+
+    clock.advance(1);
+    expect(breaker.tryAttempt()).toBe(true);
+  });
+
+  it('consumes the probe slot, so two callers racing cannot both get through', () => {
+    const { breaker, clock } = createBreaker();
+    for (let i = 0; i < 3; i++) breaker.recordFailure('down');
+
+    clock.advance(5 * MIN);
+    expect(breaker.tryAttempt()).toBe(true);
+    expect(breaker.tryAttempt()).toBe(false);
+  });
+
+  it('escalates the cooldown on each failed probe: 5m → 15m → 30m → 1h', () => {
+    const { breaker, clock } = createBreaker();
+    for (let i = 0; i < 3; i++) breaker.recordFailure('down');
+
+    const observed: number[] = [breaker.retryAfterMs()];
+    for (let i = 0; i < 3; i++) {
+      clock.advance(breaker.retryAfterMs());
+      expect(breaker.tryAttempt()).toBe(true);
+      breaker.recordFailure('probe failed');
+      observed.push(breaker.retryAfterMs());
+    }
+
+    expect(observed).toEqual([...DEFAULT_COOLDOWN_STEPS_MS]);
+  });
+
+  it('holds the last cooldown step forever rather than giving up', () => {
+    const { breaker, clock } = createBreaker();
+    for (let i = 0; i < 3; i++) breaker.recordFailure('down');
+
+    for (let i = 0; i < 10; i++) {
+      clock.advance(breaker.retryAfterMs());
+      expect(breaker.tryAttempt()).toBe(true);
+      breaker.recordFailure('probe failed');
+    }
+
+    expect(breaker.state).toBe('open');
+    expect(breaker.retryAfterMs()).toBe(60 * MIN);
+  });
+
+  it('closes on the first successful probe and resets the cooldown ladder', () => {
+    const { breaker, clock } = createBreaker();
+    for (let i = 0; i < 3; i++) breaker.recordFailure('down');
+
+    // Burn two probes so the cooldown has escalated past its first step.
+    for (let i = 0; i < 2; i++) {
+      clock.advance(breaker.retryAfterMs());
+      breaker.tryAttempt();
+      breaker.recordFailure('probe failed');
+    }
+    expect(breaker.retryAfterMs()).toBe(30 * MIN);
+
+    clock.advance(breaker.retryAfterMs());
+    breaker.tryAttempt();
+    breaker.recordSuccess();
+
+    expect(breaker.state).toBe('closed');
+    expect(breaker.consecutiveFailures).toBe(0);
+    expect(breaker.tryAttempt()).toBe(true);
+
+    // Reopening starts at the first step again, not where it left off.
+    for (let i = 0; i < 3; i++) breaker.recordFailure('down again');
+    expect(breaker.retryAfterMs()).toBe(5 * MIN);
+  });
+
+  it('counts only consecutive failures — a success in between clears the tally', () => {
+    const { breaker } = createBreaker();
+
+    breaker.recordFailure('a');
+    breaker.recordFailure('b');
+    breaker.recordSuccess();
+    breaker.recordFailure('c');
+    breaker.recordFailure('d');
+
+    expect(breaker.state).toBe('closed');
+    expect(breaker.consecutiveFailures).toBe(2);
+  });
+
+  it('honours a custom threshold and cooldown ladder', () => {
+    const { breaker, clock } = createBreaker({
+      failureThreshold: 1,
+      cooldownStepsMs: [1_000, 2_000],
+    });
+
+    breaker.recordFailure('down');
+    expect(breaker.state).toBe('open');
+    expect(breaker.retryAfterMs()).toBe(1_000);
+
+    clock.advance(1_000);
+    breaker.tryAttempt();
+    breaker.recordFailure('probe failed');
+    expect(breaker.retryAfterMs()).toBe(2_000);
+  });
+
+  it('reset() returns to the initial state without logging a recovery', () => {
+    const { breaker } = createBreaker();
+    for (let i = 0; i < 3; i++) breaker.recordFailure('down');
+
+    breaker.reset();
+
+    expect(breaker.state).toBe('closed');
+    expect(breaker.consecutiveFailures).toBe(0);
+    expect(breaker.retryAfterMs()).toBe(0);
+    expect(logSpy.warn).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining('recovered'),
+    );
+  });
+});

--- a/src/utils/circuit-breaker.ts
+++ b/src/utils/circuit-breaker.ts
@@ -1,0 +1,175 @@
+import { createChildLogger } from './logger.js';
+
+const log = createChildLogger('circuit');
+
+export type CircuitState = 'closed' | 'open';
+
+/**
+ * Waits between probes while the circuit is open: 5m → 15m → 30m → 1h.
+ * The last step repeats forever — the circuit never stops probing.
+ */
+export const DEFAULT_COOLDOWN_STEPS_MS: readonly number[] = [
+  5 * 60_000,
+  15 * 60_000,
+  30 * 60_000,
+  60 * 60_000,
+];
+
+export const DEFAULT_FAILURE_THRESHOLD = 5;
+
+export interface CircuitBreakerOptions {
+  /** Identifies the guarded loop in logs, e.g. `events` or `videoToken:<cameraId>`. */
+  label: string;
+  /** Consecutive failures that open the circuit. */
+  failureThreshold?: number;
+  /** Escalating waits between probes while open. The last entry repeats forever. */
+  cooldownStepsMs?: readonly number[];
+  /** Injectable clock, for tests. */
+  now?: () => number;
+}
+
+/**
+ * Bounds how long a retry loop keeps hammering Alarm.com.
+ *
+ * Exponential backoff already bounds the *rate* between attempts, but nothing
+ * bounds the *duration* of attempting: a saturated ladder is still an infinite
+ * loop, just a politer one. Once `failureThreshold` consecutive attempts fail
+ * the circuit opens, the loop pauses, and attempts continue only as occasional
+ * probes on an escalating cooldown — forever. One success closes it.
+ *
+ * 🔑 **The breaker cannot decide what a failure is; the caller must.**
+ * The failure that matters here is "did not produce a usable result", not
+ * "threw". In an observed multi-hour outage `fetchVideoSource()` returned
+ * `null` and `fetchVideoTokenSilent()` logged a warning and returned `null` —
+ * nothing threw and no `error` event was emitted, so to every error path in
+ * this codebase a seven-hour failure looked like a series of successful calls
+ * returning nothing. Call sites must therefore call {@link recordFailure} on
+ * their empty-result branch, not only from `catch`.
+ *
+ * Self-healing is deliberate. That outage ended when the camera was
+ * power-cycled; a breaker that stayed open until the process restarted would
+ * have kept the cameras dark long after they were healthy again.
+ *
+ * The breaker owns no timers. Each loop keeps its own scheduling and asks
+ * {@link retryAfterMs} how long to wait, so there is nothing extra to clear on
+ * shutdown.
+ */
+export class CircuitBreaker {
+  private readonly label: string;
+  private readonly failureThreshold: number;
+  private readonly cooldownStepsMs: readonly number[];
+  private readonly now: () => number;
+
+  private currentState: CircuitState = 'closed';
+  private failures = 0;
+  private cooldownIndex = 0;
+  private nextProbeAt = 0;
+  private openedAt = 0;
+
+  constructor(opts: CircuitBreakerOptions) {
+    this.label = opts.label;
+    this.failureThreshold = opts.failureThreshold ?? DEFAULT_FAILURE_THRESHOLD;
+    this.cooldownStepsMs = opts.cooldownStepsMs ?? DEFAULT_COOLDOWN_STEPS_MS;
+    this.now = opts.now ?? Date.now;
+  }
+
+  get state(): CircuitState {
+    return this.currentState;
+  }
+
+  get consecutiveFailures(): number {
+    return this.failures;
+  }
+
+  /** Milliseconds until the next attempt is permitted. Always 0 while closed. */
+  retryAfterMs(): number {
+    if (this.currentState === 'closed') return 0;
+    return Math.max(0, this.nextProbeAt - this.now());
+  }
+
+  /**
+   * Ask permission to make an attempt.
+   *
+   * Always true while closed. While open it is true only when a probe is due,
+   * and saying yes **consumes** that probe: the next one is pushed out by the
+   * current cooldown, so two callers racing at the same instant cannot both
+   * get through.
+   */
+  tryAttempt(): boolean {
+    if (this.currentState === 'closed') return true;
+
+    if (this.now() < this.nextProbeAt) return false;
+
+    this.nextProbeAt = this.now() + this.currentCooldownMs();
+    log.info(
+      { label: this.label, failures: this.failures },
+      'Circuit open — probing to see whether Alarm.com has recovered',
+    );
+    return true;
+  }
+
+  /** Record an attempt that produced a usable result. Closes the circuit. */
+  recordSuccess(): void {
+    if (this.currentState === 'open') {
+      const openForMs = this.now() - this.openedAt;
+      log.warn(
+        { label: this.label, failures: this.failures, openForMin: Math.round(openForMs / 60_000) },
+        'Circuit closed — Alarm.com recovered',
+      );
+    }
+
+    this.currentState = 'closed';
+    this.failures = 0;
+    this.cooldownIndex = 0;
+    this.nextProbeAt = 0;
+    this.openedAt = 0;
+  }
+
+  /**
+   * Record an attempt that produced no usable result — whether it threw, or
+   * returned nothing useful without throwing. Opens the circuit once
+   * `failureThreshold` consecutive failures accumulate; escalates the cooldown
+   * when a probe fails.
+   */
+  recordFailure(reason: string): void {
+    this.failures++;
+
+    if (this.currentState === 'open') {
+      this.cooldownIndex = Math.min(this.cooldownIndex + 1, this.cooldownStepsMs.length - 1);
+      this.nextProbeAt = this.now() + this.currentCooldownMs();
+      log.warn(
+        { label: this.label, failures: this.failures, nextProbeInMin: this.currentCooldownMs() / 60_000, reason },
+        'Probe failed — circuit stays open',
+      );
+      return;
+    }
+
+    if (this.failures < this.failureThreshold) return;
+
+    this.currentState = 'open';
+    this.openedAt = this.now();
+    this.cooldownIndex = 0;
+    this.nextProbeAt = this.now() + this.currentCooldownMs();
+
+    // Logged once, loudly, on the transition. Suppressed attempts afterwards
+    // are debug-level so an outage does not bury the line that explains it.
+    log.error(
+      { label: this.label, failures: this.failures, nextProbeInMin: this.currentCooldownMs() / 60_000, reason },
+      'Circuit OPEN — pausing this loop after %d consecutive failures. Probing every so often; it will close itself on the first success.',
+      this.failures,
+    );
+  }
+
+  /** Return to the initial closed state without logging a recovery. */
+  reset(): void {
+    this.currentState = 'closed';
+    this.failures = 0;
+    this.cooldownIndex = 0;
+    this.nextProbeAt = 0;
+    this.openedAt = 0;
+  }
+
+  private currentCooldownMs(): number {
+    return this.cooldownStepsMs[Math.min(this.cooldownIndex, this.cooldownStepsMs.length - 1)];
+  }
+}


### PR DESCRIPTION
Closes #9.

Backoff already bounds the **rate** between attempts. Nothing bounds the **duration** of attempting — a saturated ladder is still an infinite loop, just a politer one. Measured over ~70 minutes of a sustained Alarm.com failure, the three retry loops produced ~66 failures/hour between them and none of them ever stopped.

## The part worth reviewing closely

**The failure predicate is "produced no usable result", not "threw".**

`fetchVideoSource()` returns `null` when Alarm.com answers HTTP 200 with `errorEnum: 0` and simply omits the end-to-end WebRTC block. `fetchVideoTokenSilent()` then logs a warning and returns `null` — it does not throw, and does not emit `error`.

So a breaker wired to `catch` blocks **would not have tripped once** during a seven-hour failure. To every error path in the codebase, that outage looked like a series of successful calls returning nothing. Getting this wrong ships a circuit breaker that passes its tests, reviews clean, and sleeps through the exact class of outage it was built for.

`src/auth/token-manager.ts` therefore records a failure on the empty-result branch, and `src/auth/token-manager.test.ts` asserts the circuit opens **while no `error` event is emitted at all**.

## Scope: all three loops, not just the token poll

The issue proposes putting the breaker in `token-manager.ts`. That would leave most of the failures untouched — the event WebSocket was the dominant source by roughly 10x, because its ladder caps at 60s where the token poller's caps at 600s:

| loop | ladder cap | failures/hour | threshold added |
|---|---|---|---|
| `AlarmEventListener` | 60s | ~60 | 5 (≈2.5 min of its ladder) |
| `TokenManager` | 600s | ~6 | 3 |
| `CameraManager` | 600s | ≤6 | 6 |

## How it works

`src/utils/circuit-breaker.ts` is a state machine with an injectable clock and **no timers of its own** — each loop keeps owning its scheduling and asks `retryAfterMs()` when it schedules the next attempt, so there is nothing extra to clear on shutdown.

After N consecutive failures it opens, logs **once** at `error`, and continues only as probes on an escalating cooldown: 5 min → 15 min → 30 min → 1 hour, holding the last step forever. `tryAttempt()` *consumes* the probe slot, so two callers racing at the same instant cannot both get through.

**Self-healing is deliberate, rather than "open until restarted".** The outage that motivated this ended when the camera was power-cycled; a breaker that needed a container restart afterwards would have kept the cameras dark past the point where they were healthy again. One success closes it.

## Per-loop notes

- **`alarm-event-listener.ts`** — a socket that never reaches `open` is a failure; one that opened and later dropped is not. A flapping connection therefore does not pause a loop that Alarm.com is plainly answering, which is a different fault from an outage.
- **`camera-manager.ts`** — threshold is `BACKOFF_STEPS_MS.length + 1` on purpose, so the ladder still saturates at its 10-minute cap once before the circuit opens. Setting it equal to the ladder length makes that last rung unreachable. This also bounds `handleUnexpectedExit()`, which refetches immediately with no backoff of any kind.
- **`token-manager.ts`** — per-camera, so one sick camera does not pause the others. Note `camera-stream`'s dial-in loop shares the same breaker and can call it up to 12 times per start attempt; that is intended, since they are the same API call. A suppressed refetch returns `null` and the dial-in loop reuses its existing config, which it already handled.
- **`index.ts`** — an open circuit is reported in the periodic status line, so the logs explain why an idle camera is not being retried.

One invariant worth keeping in mind for future changes: `TokenManager`'s 600s `setInterval` must stay **unconditional**. A suppressed fetch emits nothing, which ends the camera recovery chain (*timer → fetch → emit → start → new timer*); that interval is the backstop that restarts it, and gating it on circuit state would make an open token circuit permanent.

## Verification

Built and tested against a clean clone of this repo with `npm ci` from **this** lockfile (werift 0.19.9), not against a downstream tree:

```
npm run build   clean
npm test        11 files / 136 tests  (baseline on main: 9 files / 108 tests)
```

No dependency, lockfile, or configuration changes.

Thresholds and cooldowns are module constants exported for tests, deliberately not configuration — nothing yet suggests a deployment needs different numbers, and it keeps the surface small.

## Merge order

Independent of the other open PRs and applies cleanly to `main` as it stands. It does touch `alarm-event-listener.ts` and `camera-manager.ts`, so whichever of #23/#24/#28 merges after this one will need a trivial rebase (or this one will).
