### PR TITLE
Fail a stream attempt that negotiates but never delivers media

### DIFF
--- a/src/camera/camera-stream.test.ts
+++ b/src/camera/camera-stream.test.ts
@@ -444,3 +444,87 @@ describe('CameraStream ffmpeg SDP', () => {
     expect((stream as any).h264Fmtp).toBeNull();
   });
 });
+
+/**
+ * SESSION_STARTED means the signalling handshake was accepted, not that video
+ * is flowing. Without a watchdog, a session that negotiates and then delivers
+ * nothing resolves start() successfully — CameraManager then clears
+ * failureCount and, because retries are only scheduled from its catch block,
+ * schedules nothing. The camera stops silently with state stuck at
+ * 'connecting'.
+ */
+describe('CameraStream media watchdog', () => {
+  let stream: CameraStream;
+
+  beforeEach(() => {
+    stream = new CameraStream('cam-1', 'test-camera', 'rtsp://localhost:8554');
+    vi.spyOn(stream as any, 'allocateUdpPort').mockResolvedValue(12345);
+    vi.spyOn(stream as any, 'createPeerConnection').mockReturnValue({});
+    vi.spyOn(stream as any, 'setupPeerConnection').mockImplementation(() => {});
+    vi.spyOn(stream as any, 'connectSignaling').mockResolvedValue(undefined);
+    vi.spyOn(stream as any, 'registerPostSessionHandlers').mockImplementation(() => {});
+    vi.spyOn(stream, 'stop').mockImplementation(async () => {
+      (stream as any)._state = 'idle';
+      (stream as any).settleMedia = null;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('rejects when the handshake succeeds but no track ever arrives', async () => {
+    vi.useFakeTimers();
+    const attempt = (stream as any).tryConnect(makeConfig());
+    const assertion = expect(attempt).rejects.toThrow(/no media within/);
+    await vi.advanceTimersByTimeAsync(21_000);
+    await assertion;
+  });
+
+  it('leaves state at error, not connecting, after a media timeout', async () => {
+    vi.useFakeTimers();
+    const attempt = (stream as any).tryConnect(makeConfig()).catch(() => {});
+    await vi.advanceTimersByTimeAsync(21_000);
+    await attempt;
+    expect(stream.state).toBe('error');
+  });
+
+  /**
+   * Positive control. Without it, a watchdog that ALWAYS rejected would pass
+   * both tests above.
+   */
+  it('resolves when media arrives before the timeout', async () => {
+    vi.useFakeTimers();
+    const attempt = (stream as any).tryConnect(makeConfig());
+
+    for (let i = 0; i < 50 && !(stream as any).settleMedia; i++) {
+      await Promise.resolve();
+    }
+    expect((stream as any).settleMedia, 'watchdog was never armed').not.toBeNull();
+
+    // Goes through markStreaming — the real transition the RTP subscription
+    // uses. Calling settleMedia() directly would pass even if that call site
+    // were removed, which is the mutation this test exists to catch.
+    (stream as any).markStreaming('test');
+    await expect(attempt).resolves.toBeUndefined();
+    expect(stream.state).toBe('streaming');
+  });
+
+  it('resolves immediately when the track beat the wait', async () => {
+    // The RTP subscription can set 'streaming' before awaitMedia is reached; a
+    // watchdog that missed that race would fail a healthy stream.
+    (stream as any)._state = 'streaming';
+    await expect((stream as any).awaitMedia()).resolves.toBeUndefined();
+  });
+
+  it('does not let a later track settle a waiter that stop() abandoned', async () => {
+    vi.useFakeTimers();
+    const pending = (stream as any).awaitMedia();
+    const guard = expect(pending).rejects.toThrow(/no media/);
+    await stream.stop();
+    expect((stream as any).settleMedia).toBeNull();
+    await vi.advanceTimersByTimeAsync(21_000);
+    await guard;
+  });
+});

--- a/src/camera/camera-stream.ts
+++ b/src/camera/camera-stream.ts
@@ -9,6 +9,22 @@ import type { EndToEndWebrtcConfig, RTCSessionDescriptionLike, RTCIceCandidateLi
 
 const log = createChildLogger('camera-stream');
 
+/**
+ * How long a negotiated session may stay silent before the attempt is failed.
+ *
+ * 🔴 `SESSION_STARTED` means the signalling handshake was accepted, NOT that
+ * video is flowing. Without this, a session that negotiates and then never
+ * delivers a track resolves `start()` successfully — so `CameraManager` clears
+ * `failureCount` and, because retries are only scheduled from its `catch`,
+ * schedules nothing. The camera stops silently: no error, no retry, backoff
+ * ladder reset, and `state` stuck at 'connecting' forever.
+ *
+ * Generous on purpose: ADC cameras wake on demand and the first packets can lag
+ * the handshake by several seconds. Too short turns a slow camera into a retry
+ * storm against an API that rate-limits.
+ */
+const MEDIA_TIMEOUT_MS = 20_000;
+
 const MAX_DIAL_IN_RETRIES = 12;
 const DIAL_IN_RETRY_DELAY_MS = 10_000;
 const INITIAL_WAKE_DELAY_MS = 5_000;
@@ -32,6 +48,13 @@ export class CameraStream {
 
   /** Called when ffmpeg exits unexpectedly while the stream was active. */
   onUnexpectedExit: (() => void) | null = null;
+
+  /**
+   * Resolves the media watchdog; non-null only while `tryConnect()` waits.
+   * Cleared by `stop()` too — a waiter surviving a stop would be settled by a
+   * LATER attempt's track, passing an attempt that produced nothing itself.
+   */
+  private settleMedia: (() => void) | null = null;
 
   constructor(
     readonly cameraId: string,
@@ -152,6 +175,7 @@ export class CameraStream {
     }
 
     this.h264Fmtp = null;
+    this.settleMedia = null;
     this._state = 'idle';
     log.info({ camera: this.cameraName }, 'Stream stopped');
   }
@@ -176,6 +200,60 @@ export class CameraStream {
     log.info({ camera: this.cameraName }, 'Session started, waiting for SDP offer...');
 
     this.registerPostSessionHandlers();
+
+    // 🔴 Resolving here would report success for a session that has negotiated
+    // but delivered nothing. Wait for actual media, and fail the attempt if it
+    // never arrives so CameraManager's retry path runs.
+    try {
+      await this.awaitMedia();
+    } catch (err) {
+      // stop() FIRST, then 'error' — stop() sets 'idle', so the reverse order
+      // discards the error state. It also tears down the dead peer connection,
+      // ffmpeg and socket that a timeout would otherwise leak once per retry.
+      await this.stop();
+      this._state = 'error';
+      throw err;
+    }
+  }
+
+  /**
+   * The single transition into 'streaming'.
+   *
+   * Kept as one method so the state change and the watchdog release cannot
+   * drift apart: an RTP path that set the state without settling the waiter
+   * would time out a stream that is demonstrably working.
+   */
+  private markStreaming(source: string): void {
+    this._state = 'streaming';
+    this.settleMedia?.();
+    log.info({ camera: this.cameraName, source }, 'Video streaming active');
+  }
+
+  /**
+   * Wait for the session to actually deliver media.
+   *
+   * Resolves immediately if a track already arrived: the RTP subscription can
+   * fire before this is reached, and a watchdog that missed that race would
+   * fail a perfectly healthy stream.
+   */
+  private awaitMedia(): Promise<void> {
+    if (this._state === 'streaming') return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.settleMedia = null;
+        reject(
+          new Error(
+            `no media within ${MEDIA_TIMEOUT_MS / 1000}s of SESSION_STARTED — ` +
+              'the signalling handshake succeeded but no track arrived',
+          ),
+        );
+      }, MEDIA_TIMEOUT_MS);
+      this.settleMedia = () => {
+        clearTimeout(timer);
+        this.settleMedia = null;
+        resolve();
+      };
+    });
   }
 
   private createPeerConnection(config: EndToEndWebrtcConfig): RTCPeerConnection {
@@ -297,8 +375,7 @@ export class CameraStream {
         }
       });
 
-      this._state = 'streaming';
-      log.info({ camera: this.cameraName, source }, 'Video streaming active');
+      this.markStreaming(source);
     };
 
     // Method 1: onRemoteTransceiverAdded — earliest possible, receiver may not exist yet


### PR DESCRIPTION
`SESSION_STARTED` means the signalling handshake was accepted, not that video is flowing. `tryConnect()` resolved on negotiation alone, so a session that then delivered no track was reported as a success.

### Why that matters more than it sounds

`CameraManager` schedules retries **only from its `catch` block**, and on the success path it runs `failureCount.delete(cameraId)`. So a camera that negotiates and then goes silent:

- clears its backoff ladder,
- schedules **no retry at all**,
- and leaves `state` stuck at `'connecting'` forever.

No error, no reconnect, nothing in the log to look at. The status endpoint reports a connection in progress that nothing is progressing. The stream is dead and everything about it looks calm.

### The change

`tryConnect()` now waits up to 20s after `SESSION_STARTED` for a track to arrive, and throws if none does — so the existing retry-with-a-fresh-token path runs instead of the attempt being recorded as a success.

The timeout is deliberately generous. These cameras wake on demand and the first packets can lag the handshake by several seconds; a short timeout would turn a slow camera into a retry storm against an API that rate-limits.

Four details that took some care:

- **`stop()` runs before the state is set to `'error'`.** `stop()` sets `'idle'`, so the reverse order silently discards the error state. It also tears down the peer connection, ffmpeg process and socket that a timeout would otherwise leak once per retry.
- **`awaitMedia()` resolves immediately if a track already arrived.** The RTP subscription can set `'streaming'` before the wait is reached, and a watchdog that missed that race would fail a perfectly healthy stream.
- **`stop()` clears the waiter.** One left armed across a stop would be settled by a *later* attempt's track, passing an attempt that produced nothing itself.
- **The transition into `'streaming'` is now a single `markStreaming()` method**, so the state change and the watchdog release cannot drift apart.

### Verification

Five new tests; the existing suite is unchanged and still passes (108 → 113).

Checked by mutation, because a passing suite does not distinguish a guard that works from one that never fires:

- making the watchdog never fire breaks **4** tests
- removing the settle call from `markStreaming()` breaks the positive control

That second mutation is worth mentioning: it initially broke *nothing*, because the positive-control test called the internal resolver directly and so substituted the exact wiring that could be broken. Extracting `markStreaming()` let the test drive the real transition.

⚠️ Note that the existing `camera-stream` tests all mock `tryConnect()`, so nothing previously exercised this path — the suite passing before the fix was absence of coverage rather than evidence of correctness.

### Notes

- Branched from `main` and verified against this repository's own lockfile with a fresh clone and `npm ci`.
- Touches `src/camera/camera-stream.ts`, as do #23, #24 and #28 — whichever lands last will need a trivial rebase.